### PR TITLE
refactor: use errors.NewPublic rather than fmt.Errorf

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -43,7 +43,6 @@ package protocol
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -51,6 +50,7 @@ import (
 	"github.com/cloudwego/hertz/internal/bytesconv"
 	"github.com/cloudwego/hertz/internal/bytestr"
 	"github.com/cloudwego/hertz/internal/nocopy"
+	errs "github.com/cloudwego/hertz/pkg/common/errors"
 	"github.com/cloudwego/hertz/pkg/common/utils"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
@@ -1327,7 +1327,7 @@ func ParseContentLength(b []byte) (int, error) {
 		return -1, err
 	}
 	if n != len(b) {
-		return -1, fmt.Errorf("non-numeric chars at the end of Content-Length")
+		return -1, errs.NewPublic("non-numeric chars at the end of Content-Length")
 	}
 	return v, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
refactor

#### What this PR does / why we need it (English/Chinese):
en: use errors.NewPublic in hertz rather than fmt.Errorf when string formatting is not required.
zh: 当字符串不需要格式化时，使用 hertz 的 errors.NewPublic 创建 error 而不是使用 fmt.Errorf。

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None
