### PR TITLE
refactor: simplify code in AddMissingPort

### DIFF
--- a/pkg/common/utils/path.go
+++ b/pkg/common/utils/path.go
@@ -40,11 +40,7 @@
 
 package utils
 
-import (
-	"net"
-	"strconv"
-	"strings"
-)
+import "strings"
 
 // CleanPath is the URL version of path.Clean, it returns a canonical URL path
 // for p, eliminating . and .. elements.
@@ -191,13 +187,11 @@ func bufApp(buf *[]byte, s string, w int, c byte) {
 }
 
 func AddMissingPort(addr string, isTLS bool) string {
-	n := strings.Index(addr, ":")
-	if n >= 0 {
+	if strings.IndexByte(addr, ':') >= 0 {
 		return addr
 	}
-	port := 80
-	if isTLS {
-		port = 443
+	if !isTLS {
+		return addr + ":80"
 	}
-	return net.JoinHostPort(addr, strconv.Itoa(port))
+	return addr + ":443"
 }


### PR DESCRIPTION
#### What type of PR is this?
refactor
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):

<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en:
1. When the length of substr is 1, we can call strings.IndexByte directly rather than calling len() for substr and then calling strings.IndexByte in strings.Index.
2. We can assign variable as string type instead of int type so that we are able to leave out the work about converting integer to string.
3. net.JoinHostPort() will judge whether `:` is in addr again, and will concat host and port if `:` is not in addr. However, when we call net.JoinHostPort in AddingMissingPort, `:` should not in addr. So we can also concat host and port directly instead of calling net.JoinHostPort.

zh:
1. 当子串长度确定为1时，可以直接调用 strings.IndexByte 函数而不是像 strings.Index 一样先调用 len() 判断子串长度后再调用 strings.IndexByte 函数.
2. 为省去整型数字转字符串的工作，可以将相关变量直接定义成string类型而不是int类型。
3. net包下的 JoinHostPort 函数会再次判断 `:` 是否在 addr 中，如果不在则将 host 与 port 相关字符串连接起来。然而在 AddingMissingPort 函数中调用 net.JoinHostPort 时，`:`应不在 addr 中。所以在此可以不调用 net.JoinHostPort，而是直接连接 host 和 port 信息。
#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
