### PR TITLE
optimize(recovery):use CtxErrorf instead of Errorf when server panic

### DIFF
--- a/pkg/app/middlewares/server/recovery/recovery.go
+++ b/pkg/app/middlewares/server/recovery/recovery.go
@@ -43,7 +43,7 @@ func Recovery() app.HandlerFunc {
 			if err := recover(); err != nil {
 				stack := stack(3)
 
-				hlog.Errorf("[Recovery] %s panic recovered:\n%s\n%s\n",
+				hlog.CtxErrorf(c, "[Recovery] %s panic recovered:\n%s\n%s\n",
 					timeFormat(time.Now()), err, stack)
 				ctx.AbortWithStatus(consts.StatusInternalServerError)
 			}


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):
en: use `CtxErrorf` instead of `Errorf` when server panic
zh: 使用 `CtxErrorf` 代替 `Errorf` 当服务panic
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
