### PR TITLE
feat: header add VisitAllCustomHeader method

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -1321,6 +1321,17 @@ func (h *RequestHeader) VisitAll(f func(key, value []byte)) {
 	}
 }
 
+// VisitAllCustomHeader calls f for each header in header.h which contains all headers
+// except cookie, host, content-length, content-type, user-agent and connection.
+//
+// f must not retain references to key and/or value after returning.
+// Copy key and/or value contents before returning if you need retaining them.
+//
+// To get the headers in order they were received use VisitAllInOrder.
+func (h *RequestHeader) VisitAllCustomHeader(f func(key, value []byte)) {
+	visitArgs(h.h, f)
+}
+
 func ParseContentLength(b []byte) (int, error) {
 	v, n, err := bytesconv.ParseUintBuf(b)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

feat: header add VisitAllCustomHeader method

#### What this PR does / why we need it (English/Chinese):

en: Add the VisitAllCustomHeader method to the request header, so that the incoming function f only works on custom headers( all headers except cookie, host, content-length, content-type, user-agent and connection)
zh: 在 request header 上添加 VisitAllCustomHeader 方法，使得传入的函数 f 只作用在用户自定义的 header 上（除了 cookie, host, content-length, content-type, user-agent 和 connection 以外的 header）。