### PR TITLE
fix: ci exec /bin/license-eye: exec format error

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,10 +1,10 @@
 name: Pull Request Check
 
-on: [pull_request]
+on: [ pull_request ]
 
 jobs:
   compliant:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, X64 ]
     steps:
       - uses: actions/checkout@v3
 
@@ -17,7 +17,7 @@ jobs:
         uses: crate-ci/typos@master
 
   staticcheck:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, X64 ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,10 @@
 name: Tests
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   lint-and-ut:
-    runs-on: self-hosted
+    runs-on: [ self-hosted, X64 ]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it (English/Chinese):

en: ci may be dispatched to the arm machine, resulting in an error exec format error
zh: ci 可能被调度到 arm 机器上导致报错 exec format error