### PR TITLE
feat: client removes default retry logic

### DIFF
--- a/pkg/protocol/consts/default.go
+++ b/pkg/protocol/consts/default.go
@@ -66,5 +66,5 @@ const (
 	DefaultMaxIdleConnDuration = 10 * time.Second
 
 	// DefaultMaxIdempotentCallAttempts is the default idempotent calls attempts count.
-	DefaultMaxIdempotentCallAttempts = 5
+	DefaultMaxIdempotentCallAttempts = 1
 )


### PR DESCRIPTION
#### What type of PR is this?

feat(client)

#### What this PR does / why we need it (English/Chinese):

en: Hertz client turns off the default retry logic
zh: Hertz client 关闭默认的重试逻辑
