### PR TITLE
fix: use defer to guarantee that mutex will be unlocked

### DIFF
--- a/pkg/app/fs.go
+++ b/pkg/app/fs.go
@@ -733,11 +733,11 @@ func (h *fsHandler) openIndexFile(ctx *RequestContext, dirPath string, mustCompr
 
 func (ff *fsFile) decReadersCount() {
 	ff.h.cacheLock.Lock()
+	defer ff.h.cacheLock.Unlock()
 	ff.readersCount--
 	if ff.readersCount < 0 {
 		panic("BUG: negative fsFile.readersCount!")
 	}
-	ff.h.cacheLock.Unlock()
 }
 
 func (ff *fsFile) bigFileReader() (io.Reader, error) {


### PR DESCRIPTION
#### What type of PR is this?
fix

#### What this PR does / why we need it (English/Chinese):

en: cacheLock may fail to be unlocked for potenial panic.
zh: cacheLock 可能会因潜在发生的panic导致解锁失败。
