### PR TITLE
[WIP]feat: remove special header judgement for date in resp header

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -1493,11 +1493,6 @@ func (h *ResponseHeader) setSpecialHeader(key, value []byte) bool {
 			// Transfer-Encoding is managed automatically.
 			return true
 		}
-	case 'd':
-		if utils.CaseInsensitiveCompare(bytestr.StrDate, key) {
-			// Date is managed automatically.
-			return true
-		}
 	}
 
 	return false


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it (English/Chinese):

en: In the http2 client, the client extracts the header frame first, and then adds the header to Hertz's response header. If Hertz doesn't delete this special judgement, Hertz can't add it.
zh: 在 http2 client 中，client 先解出 header frame，再将 header 添加到 Hertz 的 response header。如果不删除这个特判的话，无法添加进去
