### PR TITLE
optimize: pre-allocate slice when calling bytesconv.AppendHTTPDate

### DIFF
--- a/pkg/app/fs.go
+++ b/pkg/app/fs.go
@@ -624,7 +624,7 @@ func (h *fsHandler) newFSFile(f *os.File, fileInfo os.FileInfo, compressed bool)
 		contentLength:   contentLength,
 		compressed:      compressed,
 		lastModified:    lastModified,
-		lastModifiedStr: bytesconv.AppendHTTPDate(nil, lastModified),
+		lastModifiedStr: bytesconv.AppendHTTPDate(make([]byte, 0, len(http.TimeFormat)), lastModified),
 
 		t: time.Now(),
 	}
@@ -705,7 +705,7 @@ func (h *fsHandler) createDirIndex(base *protocol.URI, dirPath string, mustCompr
 		contentLength:   len(dirIndex),
 		compressed:      mustCompress,
 		lastModified:    lastModified,
-		lastModifiedStr: bytesconv.AppendHTTPDate(nil, lastModified),
+		lastModifiedStr: bytesconv.AppendHTTPDate(make([]byte, 0, len(http.TimeFormat)), lastModified),
 
 		t: lastModified,
 	}

--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -43,6 +43,7 @@ package protocol
 
 import (
 	"bytes"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1420,7 +1421,7 @@ func UpdateServerDate() {
 }
 
 func refreshServerDate() {
-	b := bytesconv.AppendHTTPDate(nil, time.Now())
+	b := bytesconv.AppendHTTPDate(make([]byte, 0, len(http.TimeFormat)), time.Now())
 	ServerDate.Store(b)
 }
 

--- a/pkg/protocol/header_timing_test.go
+++ b/pkg/protocol/header_timing_test.go
@@ -96,3 +96,11 @@ func BenchmarkHertzHeaderAdd(b *testing.B) {
 		zh.Add("X-tt-"+strconv.Itoa(i), "abc123456789")
 	}
 }
+
+func BenchmarkRefreshServerDate(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		refreshServerDate()
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### What this PR does / why we need it (English/Chinese):
en: Pre-allocate slice when calling bytesconv.AppendHTTPDate, which prevents extra copying.
zh: 调用bytesconv.AppendHTTPDate时，为切片预分配容量，以防止产生额外的拷贝。
