### PR TITLE
feat: release buffer in standard network `Read` method

### DIFF
--- a/pkg/network/standard/connection.go
+++ b/pkg/network/standard/connection.go
@@ -314,7 +314,11 @@ func (c *Conn) peekBuffer(i int, buf []byte) error {
 // next loads the buf with data of size i with moving read pointer.
 func (c *Conn) next(length int, b []byte) error {
 	c.peekBuffer(length, b)
-	return c.Skip(length)
+	err := c.Skip(length)
+	if err != nil {
+		return err
+	}
+	return c.Release()
 }
 
 // fill loads more data than size i, otherwise it will block read.


### PR DESCRIPTION
#### What type of PR is this?

feat

#### What this PR does / why we need it (English/Chinese):

en: Connection.Release() is called in the `Read` method of the standard network library to prevent OOM caused by not recycle memory when the `Read` method is called several times in small quantities.
zh: 标准网络库 Read 方法中调用 connecton.Release()，防止在多次少量调用 Read 方法时不回收内存导致的 OOM。

