### PR TITLE
feat:Optimize retry logic v1.0

### DIFF
--- a/pkg/app/client/client.go
+++ b/pkg/app/client/client.go
@@ -243,7 +243,7 @@ type Client struct {
 	// RetryIf controls whether a retry should be attempted after an error.
 	//
 	// By default will use isIdempotent function
-	RetryIf func(request *protocol.Request) bool
+	//RetryIf func(request *protocol.Request, err error) bool
 
 	clientFactory suite.ClientFactory
 
@@ -266,8 +266,8 @@ func (c *Client) SetProxy(p protocol.Proxy) {
 }
 
 // SetRetryIf is used to set RetryIf func.
-func (c *Client) SetRetryIf(fn func(request *protocol.Request) bool) {
-	c.RetryIf = fn
+func (c *Client) SetRetryIf(fn func(request *protocol.Request, response *protocol.Response, err error) bool) {
+	c.options.RetryConfig.RetryIf = fn
 }
 
 // SetDialFunc is used to set custom dial func.
@@ -566,23 +566,24 @@ func (c *Client) Use(mws ...Middleware) {
 
 func newHttp1OptionFromClient(c *Client) *http1.ClientOptions {
 	return &http1.ClientOptions{
-		Name:                          c.options.Name,
-		NoDefaultUserAgentHeader:      c.options.NoDefaultUserAgentHeader,
-		Dial:                          c.options.Dial,
-		DialTimeout:                   c.options.DialTimeout,
-		DialDualStack:                 c.options.DialDualStack,
-		TLSConfig:                     c.options.TLSConfig,
-		MaxConns:                      c.options.MaxConnsPerHost,
-		MaxConnDuration:               c.options.MaxConnDuration,
-		MaxIdleConnDuration:           c.options.MaxIdleConnDuration,
-		MaxIdempotentCallAttempts:     c.options.MaxIdempotentCallAttempts,
+		Name:                     c.options.Name,
+		NoDefaultUserAgentHeader: c.options.NoDefaultUserAgentHeader,
+		Dial:                     c.options.Dial,
+		DialTimeout:              c.options.DialTimeout,
+		DialDualStack:            c.options.DialDualStack,
+		TLSConfig:                c.options.TLSConfig,
+		MaxConns:                 c.options.MaxConnsPerHost,
+		MaxConnDuration:          c.options.MaxConnDuration,
+		MaxIdleConnDuration:      c.options.MaxIdleConnDuration,
+		//MaxIdempotentCallAttempts:     c.options.MaxIdempotentCallAttempts,
 		ReadTimeout:                   c.options.ReadTimeout,
 		WriteTimeout:                  c.options.WriteTimeout,
 		MaxResponseBodySize:           c.options.MaxResponseBodySize,
 		DisableHeaderNamesNormalizing: c.options.DisableHeaderNamesNormalizing,
 		DisablePathNormalizing:        c.options.DisablePathNormalizing,
 		MaxConnWaitTimeout:            c.options.MaxConnWaitTimeout,
-		RetryIf:                       c.RetryIf,
-		ResponseBodyStream:            c.options.ResponseBodyStream,
+		//RetryIf:                       c.RetryIf,
+		ResponseBodyStream: c.options.ResponseBodyStream,
+		RetryConfig:        c.options.RetryConfig,
 	}
 }

--- a/pkg/app/client/option.go
+++ b/pkg/app/client/option.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"crypto/tls"
+	"github.com/cloudwego/hertz/pkg/protocol/retry"
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/common/config"
@@ -70,11 +71,11 @@ func WithKeepAlive(b bool) config.ClientOption {
 }
 
 // WithMaxIdempotentCallAttempts sets maximum number of attempts for idempotent calls.
-func WithMaxIdempotentCallAttempts(n int) config.ClientOption {
-	return config.ClientOption{F: func(o *config.ClientOptions) {
-		o.MaxIdempotentCallAttempts = n
-	}}
-}
+//func WithMaxIdempotentCallAttempts(n int) config.ClientOption {
+//	return config.ClientOption{F: func(o *config.ClientOptions) {
+//		o.MaxIdempotentCallAttempts = n
+//	}}
+//}
 
 // WithClientReadTimeout sets maximum duration for full response reading (including body).
 func WithClientReadTimeout(t time.Duration) config.ClientOption {
@@ -139,5 +140,12 @@ func WithNoDefaultUserAgentHeader(isNoDefaultUserAgentHeader bool) config.Client
 func WithDisablePathNormalizing(isDisablePathNormalizing bool) config.ClientOption {
 	return config.ClientOption{F: func(o *config.ClientOptions) {
 		o.DisablePathNormalizing = isDisablePathNormalizing
+	}}
+}
+
+// WithRetryConfig sets RetryConfig to create an instance.
+func WithRetryConfig(retryCfg *retry.RetryConfig) config.ClientOption {
+	return config.ClientOption{F: func(o *config.ClientOptions) {
+		o.RetryConfig = retryCfg
 	}}
 }

--- a/pkg/common/config/client_option.go
+++ b/pkg/common/config/client_option.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"crypto/tls"
+	"github.com/cloudwego/hertz/pkg/protocol/retry"
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/network"
@@ -35,14 +36,14 @@ type ClientOptions struct {
 	// The max connection nums for each host
 	MaxConnsPerHost int
 
-	MaxIdleConnDuration       time.Duration
-	MaxConnDuration           time.Duration
-	MaxConnWaitTimeout        time.Duration
-	MaxIdempotentCallAttempts int
-	KeepAlive                 bool
-	ReadTimeout               time.Duration
-	TLSConfig                 *tls.Config
-	ResponseBodyStream        bool
+	MaxIdleConnDuration time.Duration
+	MaxConnDuration     time.Duration
+	MaxConnWaitTimeout  time.Duration
+	//MaxIdempotentCallAttempts int
+	KeepAlive          bool
+	ReadTimeout        time.Duration
+	TLSConfig          *tls.Config
+	ResponseBodyStream bool
 
 	// Client name. Used in User-Agent request header.
 	//
@@ -104,15 +105,17 @@ type ClientOptions struct {
 	// By default path values are normalized, i.e.
 	// extra slashes are removed, special characters are encoded.
 	DisablePathNormalizing bool
+
+	RetryConfig *retry.RetryConfig
 }
 
 func NewClientOptions(opts []ClientOption) *ClientOptions {
 	options := &ClientOptions{
-		DialTimeout:               consts.DefaultDialTimeout,
-		MaxConnsPerHost:           consts.DefaultMaxConnsPerHost,
-		MaxIdleConnDuration:       consts.DefaultMaxIdleConnDuration,
-		MaxIdempotentCallAttempts: consts.DefaultMaxIdempotentCallAttempts,
-		KeepAlive:                 true,
+		DialTimeout:         consts.DefaultDialTimeout,
+		MaxConnsPerHost:     consts.DefaultMaxConnsPerHost,
+		MaxIdleConnDuration: consts.DefaultMaxIdleConnDuration,
+		RetryConfig:         &retry.RetryConfig{},
+		KeepAlive:           true,
 	}
 	options.Apply(opts)
 

--- a/pkg/protocol/client/client.go
+++ b/pkg/protocol/client/client.go
@@ -97,8 +97,8 @@ type HostClientConfig struct {
 	MaxIdempotentCallAttempts int
 	MaxResponseBodySize       int
 
-	Dial               DialFunc
-	RetryIf            RetryIfFunc
+	Dial DialFunc
+	//RetryIf            retry.RetryIfFunc
 	ResponseBodyStream bool
 
 	DialTimeout         time.Duration
@@ -129,11 +129,6 @@ type DynamicConfig struct {
 //   - foobar.com:443
 //   - foobar.com:8080
 type DialFunc func(addr string) (network.Conn, error)
-
-// RetryIfFunc signature of retry if function
-//
-// Request argument passed to RetryIfFunc, if there are any request errors.
-type RetryIfFunc func(request *protocol.Request) bool
 
 type clientURLResponse struct {
 	statusCode int

--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -422,6 +422,11 @@ func (h *RequestHeader) IsPost() bool {
 	return bytes.Equal(h.Method(), bytestr.StrPost)
 }
 
+// IsPost returns true if request method is POST.
+func (h *RequestHeader) IsDelete() bool {
+	return bytes.Equal(h.Method(), bytestr.StrDelete)
+}
+
 // IsConnect returns true if request method is CONNECT.
 func (h *RequestHeader) IsConnect() bool {
 	return bytes.Equal(h.Method(), bytestr.StrConnect)

--- a/pkg/protocol/retry/retry.go
+++ b/pkg/protocol/retry/retry.go
@@ -1,0 +1,167 @@
+package retry
+
+import (
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+	"io"
+	"math"
+	"math/rand"
+	"time"
+)
+
+// RetryConfig All configurations related to retry
+type RetryConfig struct {
+
+	//consts.DefaultMaxIdempotentCallAttempts 最大重试次数
+	MaxIdempotentCallAttempts uint
+
+	// 重试延迟时间
+	Delay time.Duration
+
+	// 最大重试延迟时间，选择指数退避策略时，该配置会限制等待时间上限
+	MaxDelay time.Duration
+
+	// 最大抖动时间
+	MaxJitter time.Duration
+
+	//该字段待定，每次重试时进行的一次回调
+	//onRetry RetryFunc
+
+	// 发生错误时判断是否满足重试条件,当前默认 isIdempotent ，用户可指定
+	RetryIf RetryIfFunc
+
+	// CombineDelay(BackOffDelay, RandomDelay)退避策略，将多种退避策略结合在一起
+	DelayPolicy DelayPolicyFunc
+}
+
+func NewDefaultRetryConfig(retryCfg *RetryConfig) *RetryConfig {
+	// 默认关闭重试
+	if retryCfg == nil {
+		return &RetryConfig{MaxIdempotentCallAttempts: consts.DefaultMaxIdempotentCallAttempts}
+	}
+
+	cfg := &RetryConfig{
+		// 后续默认值都写在一起，这里先放着
+		MaxIdempotentCallAttempts: consts.DefaultMaxIdempotentCallAttempts,
+		Delay:                     1 * time.Millisecond,
+		MaxDelay:                  100 * time.Millisecond,
+		MaxJitter:                 10 * time.Millisecond,
+		RetryIf:                   DefaultRetryIf,
+		DelayPolicy:               CombineDelay(DefaultDelay),
+	}
+	// 不太优雅，感觉可以用 选项模式 withXXX代替，不过这样可能增加用户操作成本
+	if retryCfg.MaxIdempotentCallAttempts != 0 {
+		cfg.MaxIdempotentCallAttempts = retryCfg.MaxIdempotentCallAttempts
+	}
+	if retryCfg.Delay != 0 {
+		cfg.Delay = retryCfg.Delay
+	}
+	if retryCfg.MaxDelay != 0 {
+		cfg.MaxDelay = retryCfg.MaxDelay
+	}
+	if retryCfg.MaxJitter != 0 {
+		cfg.MaxJitter = retryCfg.MaxJitter
+	}
+	if retryCfg.RetryIf != nil {
+		cfg.RetryIf = retryCfg.RetryIf
+	}
+	if retryCfg.DelayPolicy != nil {
+		cfg.DelayPolicy = retryCfg.DelayPolicy
+	}
+	return cfg
+}
+
+// RetryIfFunc signature of retry if function
+//
+// Request argument passed to RetryIfFunc, if there are any request errors.
+type RetryIfFunc func(request *protocol.Request, response *protocol.Response, err error) bool
+
+// DelayPolicyFunc is called to return the next delay to wait after the retriable function fails on `err` after attempts.
+type DelayPolicyFunc func(attempts uint, err error, retryConfig *RetryConfig) time.Duration
+
+func DefaultRetryIf(req *protocol.Request, resp *protocol.Response, err error) bool {
+
+	if req.IsBodyStream() {
+		return false
+	}
+	// Retry non-idempotent requests if the server closes
+	// the connection before sending the response.
+	//
+	// This case is possible if the server closes the idle
+	// keep-alive connection on timeout.
+	//
+	// Apache and nginx usually do this.
+	if !isIdempotent(req, resp, err) && err == io.EOF {
+		return true
+	}
+	if resp.StatusCode() == 0 || resp.StatusCode() == 429 || (resp.StatusCode()) >= 500 && resp.StatusCode() != 501 {
+		return true
+	}
+	return false
+}
+
+func isIdempotent(req *protocol.Request, response *protocol.Response, err error) bool {
+	return req.Header.IsGet() || req.Header.IsHead() || req.Header.IsPut() || req.Header.IsDelete()
+}
+
+// DefaultDelay is a DelayPolicyFunc which keep 0 delay in all iterations
+func DefaultDelay(attempts uint, err error, retryConfig *RetryConfig) time.Duration {
+	return 0 * time.Millisecond
+}
+
+// FixedDelay is a DelayPolicyFunc which keeps delay the same through all iterations
+func FixedDelay(_ uint, _ error, retryConfig *RetryConfig) time.Duration {
+	return retryConfig.Delay
+}
+
+// RandomDelay is a DelayPolicyFunc which picks a random delay up to RetryConfig.maxJitter
+func RandomDelay(_ uint, _ error, retryConfig *RetryConfig) time.Duration {
+	return time.Duration(rand.Int63n(int64(retryConfig.MaxJitter)))
+}
+
+// BackOffDelay is a DelayPolicyFunc which increases delay between consecutive retries
+func BackOffDelay(attempts uint, _ error, retryConfig *RetryConfig) time.Duration {
+	// 1 << 63 would overflow signed int64 (time.Duration), thus 62.
+	const max uint = 62
+
+	//if retryConfig.MaxBackOffN == 0 {
+	//	if retryConfig.Delay <= 0 {
+	//		retryConfig.Delay = 1
+	//	}
+	//
+	//	retryConfig.MaxBackOffN = max - uint(math.Floor(math.Log2(float64(retryConfig.Delay))))
+	//}
+
+	if attempts > max {
+		attempts = max
+	}
+
+	return retryConfig.Delay << attempts
+}
+
+// CombineDelay is a DelayPolicy to combines all of the specified delays into a new DelayPolicyFunc
+// 将前面三种策略混合在一起共用
+func CombineDelay(delays ...DelayPolicyFunc) DelayPolicyFunc {
+	const maxInt64 = uint64(math.MaxInt64)
+
+	return func(attempts uint, err error, config *RetryConfig) time.Duration {
+		var total uint64
+		for _, delay := range delays {
+			total += uint64(delay(attempts, err, config))
+			if total > maxInt64 {
+				total = maxInt64
+			}
+		}
+
+		return time.Duration(total)
+	}
+}
+
+func Delay(attempts uint, err error, retryConfig *RetryConfig) time.Duration {
+	delayTime := retryConfig.DelayPolicy(attempts, err, retryConfig)
+	if retryConfig.MaxDelay > 0 && delayTime > retryConfig.MaxDelay {
+		delayTime = retryConfig.MaxDelay
+	}
+
+	return delayTime
+}

--- a/pkg/protocol/retry/retry_option.go
+++ b/pkg/protocol/retry/retry_option.go
@@ -1,0 +1,27 @@
+package retry
+
+import "time"
+
+type RetryOption struct {
+
+	//consts.DefaultMaxIdempotentCallAttempts 最大重试次数
+	MaxIdempotentCallAttempts uint
+
+	// 重试延迟时间
+	Delay time.Duration
+
+	// 最大重试延迟时间，选择指数退避策略时，该配置会限制等待时间上限
+	MaxDelay time.Duration
+
+	// 最大抖动时间
+	MaxJitter time.Duration
+
+	//该字段待定，每次重试时进行的一次回调
+	//onRetry RetryFunc
+
+	// 发生错误时判断是否满足重试条件,当前默认 isIdempotent ，用户可指定
+	RetryIf RetryIfFunc
+
+	// CombineDelay(BackOffDelay, RandomDelay)退避策略，将多种退避策略结合在一起
+	DelayPolicy DelayPolicyFunc
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--

optimize: retry

-->

#### What this PR does / why we need it (English/Chinese):

<!--
en: Various delay backoff strategies are introduced, and the user-defined retry conditions.
Current problems and some of my questions
1. Where to put the retryconfig structure? The current structure is not good enough. There are circular references, mainly because of pkg/common/config/client_ option. Go:: clientoptions structure introduces retryconfig
2. Specific delay blocking select statements require an end logic, that is, if there are other problems while waiting, the program should be ended
3. The initialization when the user injects retryconfig into the client is not elegant enough, and the form of withxxx is also considered?
4.pkg/protocol/client/client. Use of hostclientconfig of go

zh:引入了各种延迟退避策略，用户自定义重试发生条件。
目前存在的问题以及我的一些疑问
1.RetryConfig 结构体放哪里，我放的位置目前结构不够好，存在循环引用，主要是因为pkg/common/config/client_option.go :: ClientOptions 结构体引入了 RetryConfig 
2.具体延时阻塞的select 语句那里，需要一个结束的逻辑，即如果在等待时有其他问题要结束程序
3.用户将RetryConfig注入client时的初始化不够优雅，也考虑用withXXX的形式？
4.pkg/protocol/client/client.go 的HostClientConfig 用处

注释内容还是中文，后续我会改为英文
-->

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Fixes ([paste link of issue](https://github.com/cloudwego/hertz/issues/63))
-->
