### PR TITLE
fix: missing reset isTLS field when recycle Request

### DIFF
--- a/pkg/protocol/request.go
+++ b/pkg/protocol/request.go
@@ -177,6 +177,7 @@ func (req *Request) ResetSkipHeader() {
 	req.parsedURI = false
 	req.parsedPostArgs = false
 	req.postArgs.Reset()
+	req.isTLS = false
 }
 
 func SwapRequestBody(a, b *Request) {
@@ -310,7 +311,8 @@ func (req *Request) Host() []byte {
 	return req.URI().Host()
 }
 
-// SetIsTLS is used to set isTLS
+// SetIsTLS is used by TLS server to mark whether the request is a TLS request.
+// Client shouldn't use this method but should depend on the uri.scheme instead.
 func (req *Request) SetIsTLS(isTLS bool) {
 	req.isTLS = isTLS
 }


### PR DESCRIPTION
#### What type of PR is this?

fix 

#### What this PR does / why we need it (English/Chinese):

EN: fix the bug that `isTLS` field is not reset when recycle Request
ZH: 修复了 `isTLS` 字段在 Request 回收阶段未正确重置的问题

#### Which issue(s) this PR fixes:

fixes #163 