### PR TITLE
refactor: distinguish between global dialer and local dialer

### DIFF
--- a/pkg/app/client/client.go
+++ b/pkg/app/client/client.go
@@ -53,7 +53,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/config"
 	"github.com/cloudwego/hertz/pkg/common/errors"
 	"github.com/cloudwego/hertz/pkg/common/utils"
-	"github.com/cloudwego/hertz/pkg/network"
+	"github.com/cloudwego/hertz/pkg/network/dialer"
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/cloudwego/hertz/pkg/protocol/client"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
@@ -269,11 +269,6 @@ func (c *Client) SetProxy(p protocol.Proxy) {
 // SetRetryIf is used to set RetryIf func.
 func (c *Client) SetRetryIf(fn func(request *protocol.Request) bool) {
 	c.RetryIf = fn
-}
-
-// SetDialFunc is used to set custom dial func.
-func (c *Client) SetDialFunc(dial func(addr string) (network.Conn, error)) {
-	c.options.Dial = dial
 }
 
 // Get returns the status code and body of url.
@@ -548,6 +543,9 @@ func (c *Client) SetClientFactory(cf suite.ClientFactory) {
 // NewClient return a client with options
 func NewClient(opts ...config.ClientOption) (*Client, error) {
 	opt := config.NewClientOptions(opts)
+	if opt.Dialer == nil {
+		opt.Dialer = dialer.DefaultDialer()
+	}
 	c := &Client{
 		options: opt,
 	}
@@ -569,7 +567,7 @@ func newHttp1OptionFromClient(c *Client) *http1.ClientOptions {
 	return &http1.ClientOptions{
 		Name:                          c.options.Name,
 		NoDefaultUserAgentHeader:      c.options.NoDefaultUserAgentHeader,
-		Dial:                          c.options.Dial,
+		Dialer:                        c.options.Dialer,
 		DialTimeout:                   c.options.DialTimeout,
 		DialDualStack:                 c.options.DialDualStack,
 		TLSConfig:                     c.options.TLSConfig,

--- a/pkg/app/client/option.go
+++ b/pkg/app/client/option.go
@@ -22,9 +22,7 @@ import (
 
 	"github.com/cloudwego/hertz/pkg/common/config"
 	"github.com/cloudwego/hertz/pkg/network"
-	"github.com/cloudwego/hertz/pkg/network/dialer"
 	"github.com/cloudwego/hertz/pkg/network/standard"
-	"github.com/cloudwego/hertz/pkg/protocol/client"
 )
 
 // WithDialTimeout sets dial timeout.
@@ -87,14 +85,14 @@ func WithClientReadTimeout(t time.Duration) config.ClientOption {
 func WithTLSConfig(cfg *tls.Config) config.ClientOption {
 	return config.ClientOption{F: func(o *config.ClientOptions) {
 		o.TLSConfig = cfg
-		dialer.SetDialer(standard.NewDialer())
+		o.Dialer = standard.NewDialer()
 	}}
 }
 
 // WithDialer sets the specific dialer.
 func WithDialer(d network.Dialer) config.ClientOption {
 	return config.ClientOption{F: func(o *config.ClientOptions) {
-		dialer.SetDialer(d)
+		o.Dialer = d
 	}}
 }
 
@@ -102,15 +100,6 @@ func WithDialer(d network.Dialer) config.ClientOption {
 func WithResponseBodyStream(b bool) config.ClientOption {
 	return config.ClientOption{F: func(o *config.ClientOptions) {
 		o.ResponseBodyStream = b
-	}}
-}
-
-// WithDialFunc is used to set dialer function
-//
-// NOTE: By default, hertz client uses dialer.DialConnection as DialFunc.
-func WithDialFunc(f client.DialFunc) config.ClientOption {
-	return config.ClientOption{F: func(o *config.ClientOptions) {
-		o.Dial = f
 	}}
 }
 

--- a/pkg/common/config/client_option.go
+++ b/pkg/common/config/client_option.go
@@ -53,15 +53,14 @@ type ClientOptions struct {
 	// User-Agent header to be excluded from the Request.
 	NoDefaultUserAgentHeader bool
 
-	// Callback for establishing new connections to hosts.
-	//
-	// Default Dial is used if not set.
-	Dial func(addr string) (network.Conn, error)
+	// Dialer is the custom dialer used to establish connection.
+	// Default Dialer is used if not set.
+	Dialer network.Dialer
 
 	// Attempt to connect to both ipv4 and ipv6 addresses if set to true.
 	//
 	// This option is used only if default TCP dialer is used,
-	// i.e. if Dial is blank.
+	// i.e. if Dialer is blank.
 	//
 	// By default client connects only to ipv4 addresses,
 	// since unfortunately ipv6 remains broken in many networks worldwide :)

--- a/pkg/network/dialer/dialer.go
+++ b/pkg/network/dialer/dialer.go
@@ -26,8 +26,14 @@ import (
 
 var defaultDialer network.Dialer
 
+// SetDialer is used to set the global default dialer.
+// Deprecated: use WithDialer instead.
 func SetDialer(dialer network.Dialer) {
 	defaultDialer = dialer
+}
+
+func DefaultDialer() network.Dialer {
+	return defaultDialer
 }
 
 func DialConnection(network, address string, timeout time.Duration, tlsConfig *tls.Config) (conn network.Conn, err error) {

--- a/pkg/protocol/client/client.go
+++ b/pkg/protocol/client/client.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/config"
 	"github.com/cloudwego/hertz/pkg/common/errors"
 	"github.com/cloudwego/hertz/pkg/common/timer"
-	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
@@ -97,7 +96,6 @@ type HostClientConfig struct {
 	MaxIdempotentCallAttempts int
 	MaxResponseBodySize       int
 
-	Dial               DialFunc
 	RetryIf            RetryIfFunc
 	ResponseBodyStream bool
 
@@ -115,20 +113,6 @@ type DynamicConfig struct {
 	ProxyURI *protocol.URI
 	IsTLS    bool
 }
-
-// DialFunc must establish connection to addr.
-//
-// There is no need in establishing TLS (SSL) connection for https.
-// The client automatically converts connection to TLS
-// if HostClient.IsTLS is set.
-//
-// TCP address passed to DialFunc always contains host and port.
-// Example TCP addr values:
-//
-//   - foobar.com:80
-//   - foobar.com:443
-//   - foobar.com:8080
-type DialFunc func(addr string) (network.Conn, error)
 
 // RetryIfFunc signature of retry if function
 //

--- a/pkg/protocol/consts/default.go
+++ b/pkg/protocol/consts/default.go
@@ -52,7 +52,7 @@ const (
 
 	// *** Client default value start from here ***
 
-	// DefaultDialTimeout is timeout used by Dial and DialDualStack
+	// DefaultDialTimeout is timeout used by Dialer and DialDualStack
 	// for establishing TCP connections.
 	DefaultDialTimeout = time.Second
 

--- a/pkg/protocol/http1/proxy/proxy.go
+++ b/pkg/protocol/http1/proxy/proxy.go
@@ -34,14 +34,13 @@ import (
 	"github.com/cloudwego/hertz/internal/bytesconv"
 	"github.com/cloudwego/hertz/internal/bytestr"
 	"github.com/cloudwego/hertz/pkg/network"
-	"github.com/cloudwego/hertz/pkg/network/dialer"
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 	reqI "github.com/cloudwego/hertz/pkg/protocol/http1/req"
 	respI "github.com/cloudwego/hertz/pkg/protocol/http1/resp"
 )
 
-func SetupProxy(conn network.Conn, addr string, proxyURI *protocol.URI, tlsConfig *tls.Config, isTLS bool) (network.Conn, error) {
+func SetupProxy(conn network.Conn, addr string, proxyURI *protocol.URI, tlsConfig *tls.Config, isTLS bool, dialer network.Dialer) (network.Conn, error) {
 	var err error
 	if bytes.Equal(proxyURI.Scheme(), bytestr.StrHTTPS) {
 		conn, err = dialer.AddTLS(conn, tlsConfig)


### PR DESCRIPTION
#### What type of PR is this?

refactor

#### What this PR does / why we need it (English/Chinese):

EN: distinguish between global dialer and local dialer & remove dialFunc(use dialer as an alternative)
ZH：区别全局默认dialer和client 局部dialer（指定了dialer的client不再受全局dialer改变而改变）修改全局dialer影响面较大，标记deprecated，后续统一到client初始化时传参指定dialer方式修改局部dialer，以及移除了功能完全被dialer覆盖的dialFunc扩展
