### PR TITLE
fix: get wrong local loopback IPv6

### DIFF
--- a/pkg/common/utils/network.go
+++ b/pkg/common/utils/network.go
@@ -31,16 +31,25 @@ func LocalIP() string {
 
 // getLocalIp enumerates local net interfaces to find local ip, it should only be called in init phase
 func getLocalIp() string {
-	addrs, err := net.InterfaceAddrs()
+	inters, err := net.Interfaces()
 	if err != nil {
 		return UNKNOWN_IP_ADDR
 	}
-
-	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			return ipnet.IP.String()
+	for _, inter := range inters {
+		if inter.Flags&net.FlagLoopback != net.FlagLoopback &&
+			inter.Flags&net.FlagUp != 0 {
+			addrs, err := inter.Addrs()
+			if err != nil {
+				return UNKNOWN_IP_ADDR
+			}
+			for _, addr := range addrs {
+				if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+					return ipnet.IP.String()
+				}
+			}
 		}
 	}
+
 	return UNKNOWN_IP_ADDR
 }
 


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (English/Chinese):
- zh: 获取到了错误的ipv6本地回环地址
- en: get wrong local loopback IPV6
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->

#### Which issue(s) this PR fixes:
本地环境获取localip时获取到 `fe80::1%lo0`，不符合预期。
```
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
	inet 127.0.0.1 netmask 0xff000000
	inet6 ::1 prefixlen 128
	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
	nd6 options=201<PERFORMNUD,DAD>
```
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
