### PR TITLE
optimize: add RequestContext.SetCookie Method

### DIFF
--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -47,6 +47,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -948,6 +949,40 @@ func (ctx *RequestContext) ContentType() []byte {
 // Cookie returns the value of the request cookie key.
 func (ctx *RequestContext) Cookie(key string) []byte {
 	return ctx.Request.Header.Cookie(key)
+}
+
+// SetCookie adds a Set-Cookie header to the Response's headers.
+//  Parameter introduce:
+//  name and value is used to set cookie's name and value, eg. Set-Cookie: name=value
+//  maxAge is use to set cookie's expiry date, eg. Set-Cookie: name=value; max-age=1
+//  path and domain is used to set the scope of a cookie, eg. Set-Cookie: name=value;domain=localhost; path=/;
+//  secure and httpOnly is used to sent cookies securely; eg. Set-Cookie: name=value;HttpOnly; secure;
+//  sameSite let servers specify whether/when cookies are sent with cross-site requests; eg. Set-Cookie: name=value;HttpOnly; secure; SameSite=Lax;
+//
+//  For example:
+//  1. ctx.SetCookie("user", "hertz", 1, "/", "localhost",protocol.CookieSameSiteLaxMode, true, true)
+//  add response header --->  Set-Cookie: user=hertz; max-age=1; domain=localhost; path=/; HttpOnly; secure; SameSite=Lax;
+//  2. ctx.SetCookie("user", "hertz", 10, "/", "localhost",protocol.CookieSameSiteLaxMode, false, false)
+//  add response header --->  Set-Cookie: user=hertz; max-age=10; domain=localhost; path=/; SameSite=Lax;
+//  3. ctx.SetCookie("", "hertz", 10, "/", "localhost",protocol.CookieSameSiteLaxMode, false, false)
+//  add response header --->  Set-Cookie: hertz; max-age=10; domain=localhost; path=/; SameSite=Lax;
+//  4. ctx.SetCookie("user", "", 10, "/", "localhost",protocol.CookieSameSiteLaxMode, false, false)
+//  add response header --->  Set-Cookie: user=; max-age=10; domain=localhost; path=/; SameSite=Lax;
+func (ctx *RequestContext) SetCookie(name, value string, maxAge int, path, domain string, sameSite protocol.CookieSameSite, secure, httpOnly bool) {
+	if path == "" {
+		path = "/"
+	}
+	cookie := protocol.AcquireCookie()
+	defer protocol.ReleaseCookie(cookie)
+	cookie.SetKey(name)
+	cookie.SetValue(url.QueryEscape(value))
+	cookie.SetMaxAge(maxAge)
+	cookie.SetPath(path)
+	cookie.SetDomain(domain)
+	cookie.SetSecure(secure)
+	cookie.SetHTTPOnly(httpOnly)
+	cookie.SetSameSite(sameSite)
+	ctx.Response.Header.SetCookie(cookie)
 }
 
 // UserAgent returns the value of the request user_agent.

--- a/pkg/app/context_test.go
+++ b/pkg/app/context_test.go
@@ -919,3 +919,15 @@ func TestBindAndValidate(t *testing.T) {
 		t.Fatalf("unexpected nil, expected an error")
 	}
 }
+
+func TestRequestContext_SetCookie(t *testing.T) {
+	c := NewContext(0)
+	c.SetCookie("user", "hertz", 1, "/", "localhost", protocol.CookieSameSiteLaxMode, true, true)
+	assert.DeepEqual(t, "user=hertz; max-age=1; domain=localhost; path=/; HttpOnly; secure; SameSite=Lax", c.Response.Header.Get("Set-Cookie"))
+}
+
+func TestRequestContext_SetCookiePathEmpty(t *testing.T) {
+	c := NewContext(0)
+	c.SetCookie("user", "hertz", 1, "", "localhost", protocol.CookieSameSiteDisabled, true, true)
+	assert.DeepEqual(t, "user=hertz; max-age=1; domain=localhost; path=/; HttpOnly; secure", c.Response.Header.Get("Set-Cookie"))
+}


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
- 添加 RequestContext.SetCookie 方法

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: add RequestContext.SetCookie Method
zh(optional): 添加 RequestContext.SetCookie 方法

#### Which issue(s) this PR fixes:
currently hertz is used to set cookies:
```go
 h.GET("/cookie", func(ctx context.Context, c *app.RequestContext) {
     // set a cookie
     cookie := protocol.AcquireCookie()
     cookie.SetKey("myCookie")
     cookie.SetValue("a nice cookie!")
     cookie.SetExpire(time.Now().Add(3600 * time.Second))
     cookie.SetPath("/")
     cookie.SetHTTPOnly(true)
     cookie.SetSecure(false)
     c.Response.Header.SetCookie(cookie)
     protocol.ReleaseCookie(cookie)
     c.WriteString("A cookie is ready.")
     return
}
```
after:
```go
 h.GET("/cookie", func(ctx context.Context, c *app.RequestContext) {
     // set a cookie
     c.SetCookie("user", "hertz", 1, "/", "localhost", true, true)
     c.WriteString("A cookie is ready.")
     return
}
```
