### PR TITLE
fix: fix path-traversal bug

### DIFF
--- a/internal/bytestr/bytes.go
+++ b/internal/bytestr/bytes.go
@@ -28,6 +28,7 @@ var (
 )
 
 var (
+	StrBackSlash        = []byte("\\")
 	StrSlash            = []byte("/")
 	StrSlashSlash       = []byte("//")
 	StrSlashDotDot      = []byte("/..")

--- a/pkg/protocol/uri.go
+++ b/pkg/protocol/uri.go
@@ -318,9 +318,9 @@ func (u *URI) SetHostBytes(host []byte) {
 //
 // Examples:
 //
-//    * For /foo/bar/baz.html path returns baz.html.
-//    * For /foo/bar/ returns empty byte slice.
-//    * For /foobar.js returns foobar.js.
+//   - For /foo/bar/baz.html path returns baz.html.
+//   - For /foo/bar/ returns empty byte slice.
+//   - For /foobar.js returns foobar.js.
 func (u *URI) LastPathSegment() []byte {
 	path := u.Path()
 	n := bytes.LastIndexByte(path, '/')
@@ -334,14 +334,14 @@ func (u *URI) LastPathSegment() []byte {
 //
 // The following newURI types are accepted:
 //
-//     * Absolute, i.e. http://foobar.com/aaa/bb?cc . In this case the original
-//       uri is replaced by newURI.
-//     * Absolute without scheme, i.e. //foobar.com/aaa/bb?cc. In this case
-//       the original scheme is preserved.
-//     * Missing host, i.e. /aaa/bb?cc . In this case only RequestURI part
-//       of the original uri is replaced.
-//     * Relative path, i.e.  xx?yy=abc . In this case the original RequestURI
-//       is updated according to the new relative path.
+//   - Absolute, i.e. http://foobar.com/aaa/bb?cc . In this case the original
+//     uri is replaced by newURI.
+//   - Absolute without scheme, i.e. //foobar.com/aaa/bb?cc. In this case
+//     the original scheme is preserved.
+//   - Missing host, i.e. /aaa/bb?cc . In this case only RequestURI part
+//     of the original uri is replaced.
+//   - Relative path, i.e.  xx?yy=abc . In this case the original RequestURI
+//     is updated according to the new relative path.
 func (u *URI) Update(newURI string) {
 	u.UpdateBytes(bytesconv.S2b(newURI))
 }
@@ -350,14 +350,14 @@ func (u *URI) Update(newURI string) {
 //
 // The following newURI types are accepted:
 //
-//     * Absolute, i.e. http://foobar.com/aaa/bb?cc . In this case the original
-//       uri is replaced by newURI.
-//     * Absolute without scheme, i.e. //foobar.com/aaa/bb?cc. In this case
-//       the original scheme is preserved.
-//     * Missing host, i.e. /aaa/bb?cc . In this case only RequestURI part
-//       of the original uri is replaced.
-//     * Relative path, i.e.  xx?yy=abc . In this case the original RequestURI
-//       is updated according to the new relative path.
+//   - Absolute, i.e. http://foobar.com/aaa/bb?cc . In this case the original
+//     uri is replaced by newURI.
+//   - Absolute without scheme, i.e. //foobar.com/aaa/bb?cc. In this case
+//     the original scheme is preserved.
+//   - Missing host, i.e. /aaa/bb?cc . In this case only RequestURI part
+//     of the original uri is replaced.
+//   - Relative path, i.e.  xx?yy=abc . In this case the original RequestURI
+//     is updated according to the new relative path.
 func (u *URI) UpdateBytes(newURI []byte) {
 	u.requestURI = u.updateBytes(newURI, u.requestURI)
 }
@@ -480,6 +480,15 @@ func splitHostURI(host, uri []byte) ([]byte, []byte, []byte) {
 }
 
 func normalizePath(dst, src []byte) []byte {
+	// replace all backslashes with forward slashes
+	for {
+		n := bytes.Index(src, bytestr.StrBackSlash)
+		if n < 0 {
+			break
+		}
+		src[n] = '/'
+	}
+
 	dst = dst[:0]
 	dst = addLeadingSlash(dst, src)
 	dst = decodeArgAppendNoPlus(dst, src)

--- a/pkg/protocol/uri_test.go
+++ b/pkg/protocol/uri_test.go
@@ -228,3 +228,19 @@ func testURIFullURI(t *testing.T, scheme, host, path, hash string, args *Args, e
 		t.Fatalf("Unexpected URI: %q. Expected %q", uri, expectedURI)
 	}
 }
+
+func TestParsePath(t *testing.T) {
+	t.Parallel()
+
+	testParsePath(t, "/../../../../../foo", "/foo")
+	testParsePath(t, "/..\\..\\..\\..\\..\\foo", "/foo")
+}
+
+func testParsePath(t *testing.T, path, expectedPath string) {
+	var u URI
+	u.Parse(nil, []byte(path))
+	parsedPath := u.Path()
+	if string(parsedPath) != expectedPath {
+		t.Fatalf("Unexpected Path: %q. Expected %q", parsedPath, expectedPath)
+	}
+}

--- a/pkg/protocol/uri_test.go
+++ b/pkg/protocol/uri_test.go
@@ -234,6 +234,7 @@ func TestParsePath(t *testing.T) {
 
 	testParsePath(t, "/../../../../../foo", "/foo")
 	testParsePath(t, "/..\\..\\..\\..\\..\\foo", "/foo")
+	testParsePath(t, "/..%5c..%5cfoo", "/foo")
 }
 
 func testParsePath(t *testing.T, path, expectedPath string) {

--- a/pkg/protocol/uri_test.go
+++ b/pkg/protocol/uri_test.go
@@ -43,6 +43,7 @@ package protocol
 
 import (
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -229,19 +230,19 @@ func testURIFullURI(t *testing.T, scheme, host, path, hash string, args *Args, e
 	}
 }
 
-func TestParsePath(t *testing.T) {
+func TestParsePathWindows(t *testing.T) {
 	t.Parallel()
 
-	testParsePath(t, "/../../../../../foo", "/foo")
-	testParsePath(t, "/..\\..\\..\\..\\..\\foo", "/foo")
-	testParsePath(t, "/..%5c..%5cfoo", "/foo")
+	testParsePathWindows(t, "/../../../../../foo", "/foo")
+	testParsePathWindows(t, "/..\\..\\..\\..\\..\\foo", "/foo")
+	testParsePathWindows(t, "/..%5c..%5cfoo", "/foo")
 }
 
-func testParsePath(t *testing.T, path, expectedPath string) {
+func testParsePathWindows(t *testing.T, path, expectedPath string) {
 	var u URI
 	u.Parse(nil, []byte(path))
 	parsedPath := u.Path()
-	if string(parsedPath) != expectedPath {
+	if filepath.Separator == '\\' && string(parsedPath) != expectedPath {
 		t.Fatalf("Unexpected Path: %q. Expected %q", parsedPath, expectedPath)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

fix: A bug fix 

#### Check the PR title.

- [x] This PR title match the format: <type>(optional scope): <description>

- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### (Optional) Translate the PR title into Chinese.

修复目录穿越漏洞

#### (Optional) More detail description for this PR(en: English/zh: Chinese).

en: fix by simply replace all backslashes with forward slashes
zh(optional): 将反斜杠全部改成正斜杠

#### Which issue(s) this PR fixes:

Fixes https://github.com/cloudwego/hertz/issues/228

Currently hertz has no restriction on backslash in `normalizePath` function.

```go
func normalizePath(dst, src []byte) []byte {
	dst = dst[:0]
	dst = addLeadingSlash(dst, src)
	dst = decodeArgAppendNoPlus(dst, src)

	// remove duplicate slashes
	b := dst
	bSize := len(b)
	for {
		n := bytes.Index(b, bytestr.StrSlashSlash)
		if n < 0 {
			break
		}
		b = b[n:]
		copy(b, b[1:])
		b = b[:len(b)-1]
		bSize--
	}
	dst = dst[:bSize]

	// remove /./ parts
	b = dst
	for {
		n := bytes.Index(b, bytestr.StrSlashDotSlash)
		if n < 0 {
			break
		}
		nn := n + len(bytestr.StrSlashDotSlash) - 1
		copy(b[n:], b[nn:])
		b = b[:len(b)-nn+n]
	}

	// remove /foo/../ parts
	for {
		n := bytes.Index(b, bytestr.StrSlashDotDotSlash)
		if n < 0 {
			break
		}
		nn := bytes.LastIndexByte(b[:n], '/')
		if nn < 0 {
			nn = 0
		}
		n += len(bytestr.StrSlashDotDotSlash) - 1
		copy(b[nn:], b[n:])
		b = b[:len(b)-n+nn]
	}

	// remove trailing /foo/..
	n := bytes.LastIndex(b, bytestr.StrSlashDotDot)
	if n >= 0 && n+len(bytestr.StrSlashDotDot) == len(b) {
		nn := bytes.LastIndexByte(b[:n], '/')
		if nn < 0 {
			return bytestr.StrSlash
		}
		b = b[:nn+1]
	}

	return b
}
```

After:

```go
func normalizePath(dst, src []byte) []byte {
	// replace all backslashes with forward slashes
	for {
		n := bytes.Index(src, bytestr.StrBackSlash)
		if n < 0 {
			break
		}
		src[n] = '/'
	}
	...
}
```


