### PR TITLE
fix: fix some tsr bugs

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -419,7 +419,7 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 			search = search[i:]
 			searchIndex = searchIndex + i
 			if search == nilString {
-				if cd := cn.findChild('/'); cd != nil && cd.handlers != nil {
+				if cd := cn.findChild('/'); cd != nil && (cd.handlers != nil || cd.anyChild != nil) {
 					res.tsr = true
 				}
 			}

--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -394,7 +394,7 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 		}
 
 		if search == nilString {
-			if cd := cn.findChild('/'); cd != nil && cd.handlers != nil {
+			if cd := cn.findChild('/'); cd != nil && (cd.handlers != nil || cd.anyChild != nil) {
 				res.tsr = true
 			}
 		}

--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -361,7 +361,8 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 				searchIndex = searchIndex + len(cn.prefix)
 			} else {
 				// not equal
-				if (len(cn.prefix) == len(search)+1) && (cn.prefix[len(search)]) == '/' && (cn.handlers != nil || cn.anyChild != nil) {
+				if (len(cn.prefix) == len(search)+1) &&
+					(cn.prefix[len(search)]) == '/' && cn.prefix[:len(search)] == search && (cn.handlers != nil || cn.anyChild != nil) {
 					res.tsr = true
 				}
 				// No matching prefix, let's backtrack to the first possible alternative node of the decision path

--- a/pkg/route/tree_test.go
+++ b/pkg/route/tree_test.go
@@ -471,6 +471,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/no/a",
 		"/no/b",
 		"/api/hello/:name",
+		"/user/:name/*id",
 	}
 	for _, route := range routes {
 		recv := catchPanic(func() {
@@ -496,6 +497,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/admin/config/",
 		"/admin/config/permissions/",
 		"/doc/",
+		"/user/name",
 	}
 	v := make(param.Params, 0, 10)
 	for _, route := range tsrRoutes {

--- a/pkg/route/tree_test.go
+++ b/pkg/route/tree_test.go
@@ -461,7 +461,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/1/:id/",
 		"/1/:id/2",
 		"/aa",
-		"/a/",
+		"/a/*b",
 		"/admin",
 		"/admin/:category",
 		"/admin/:category/:page",

--- a/pkg/route/tree_test.go
+++ b/pkg/route/tree_test.go
@@ -461,7 +461,7 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/1/:id/",
 		"/1/:id/2",
 		"/aa",
-		"/a/*b",
+		"/a/",
 		"/admin",
 		"/admin/:category",
 		"/admin/:category/:page",
@@ -472,6 +472,13 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/no/b",
 		"/api/hello/:name",
 		"/user/:name/*id",
+		"/resource",
+		"/r/*id",
+		"/book/biz/:name",
+		"/book/biz/abc",
+		"/book/biz/abc/bar",
+		"/book/:page/:name",
+		"/book/hello/:name/biz/",
 	}
 	for _, route := range routes {
 		recv := catchPanic(func() {
@@ -498,6 +505,10 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/admin/config/permissions/",
 		"/doc/",
 		"/user/name",
+		"/r",
+		"/book/hello/a/biz",
+		"/book/biz/foo/",
+		"/book/biz/abc/bar/",
 	}
 	v := make(param.Params, 0, 10)
 	for _, route := range tsrRoutes {
@@ -516,6 +527,10 @@ func TestTreeTrailingSlashRedirect(t *testing.T) {
 		"/_",
 		"/_/",
 		"/api/world/abc",
+		"/book",
+		"/book/",
+		"/book/hello/a/abc",
+		"/book/biz/abc/biz",
 	}
 	for _, route := range noTsrRoutes {
 		value := tree.find(route, &v, false)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix: A bug fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复一些tsr参数返回错误的bug

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: 1.Registering the route "/a/:b/*c", then request the path "/a/b", the find function in tree.go will return a false tsr so that server return 404 page not found.
2.Registering the route "/aa" and "/a/*b", then request the path "/a", the find function will return a false tsr
3.There's something wrong with the if conditional logic
![image](https://user-images.githubusercontent.com/45221305/188773334-a11623f5-7137-4503-93df-bf3d86f6ba9c.png)

zh(optional):1.注册"/a/:b/*c"路由，然后发起请求访问/a/b，文件tree.go中find函数会返回一个false的tsr导致无法自动重定向，因此服务端返回了404
2.同时注册"/aa"和"/a/*b", 然后发起请求访问/a，find函数返回false的tsr
3.在上图的if判断语句中存在一些逻辑错误，因为代码走到这的时候search和cn.prefix的前缀并不一定相等

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [#231](https://github.com/cloudwego/hertz/issues/231)