### PR TITLE
feat: errors support format

### DIFF
--- a/pkg/common/errors/errors.go
+++ b/pkg/common/errors/errors.go
@@ -222,3 +222,15 @@ func NewPublic(err string) *Error {
 func NewPrivate(err string) *Error {
 	return New(errors.New(err), ErrorTypePrivate, nil)
 }
+
+func Newf(t ErrorType, meta interface{}, format string, v ...interface{}) *Error {
+	return New(fmt.Errorf(format, v...), t, meta)
+}
+
+func NewPublicf(format string, v ...interface{}) *Error {
+	return New(fmt.Errorf(format, v...), ErrorTypePublic, nil)
+}
+
+func NewPrivatef(format string, v ...interface{}) *Error {
+	return New(fmt.Errorf(format, v...), ErrorTypePrivate, nil)
+}

--- a/pkg/common/errors/errors_test.go
+++ b/pkg/common/errors/errors_test.go
@@ -130,3 +130,12 @@ Error #03: third
 	assert.Nil(t, errs.JSON())
 	assert.DeepEqual(t, "", errs.String())
 }
+
+func TestErrorFormat(t *testing.T) {
+	err := Newf(ErrorTypeAny, nil, "caused by %s", "reason")
+	assert.DeepEqual(t, New(errors.New("caused by reason"), ErrorTypeAny, nil), err)
+	publicErr := NewPublicf("caused by %s", "reason")
+	assert.DeepEqual(t, New(errors.New("caused by reason"), ErrorTypePublic, nil), publicErr)
+	privateErr := NewPrivatef("caused by %s", "reason")
+	assert.DeepEqual(t, New(errors.New("caused by reason"), ErrorTypePrivate, nil), privateErr)
+}


### PR DESCRIPTION
#### What type of PR is this?

feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

#### Translate the PR title into Chinese.

支持`error`的格式化

#### More detail description for this PR(en: English/zh: Chinese).

en: Add three methods: `errors.Newf`, `errors.NewPublicf`, `errors.NewPrivatef` whit unit tests.

zh: 添加了三个方法：`errors.Newf`，`errors.NewPublicf`，`errors.NewPrivatef`，并补充了单元测试。

#### Which issue(s) this PR fixes:

Fixes #248 

