### PR TITLE
optimize: add a option to controls whether debugPrintRoute executes

### DIFF
--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -288,3 +288,11 @@ func WithAutoReloadRender(b bool, interval time.Duration) config.Option {
 		o.AutoReloadInterval = interval
 	}}
 }
+
+// WithDebugPrintRoute sets whether enable debugPrintRoute
+// If we don't set it, it will default to true
+func WithDebugPrintRoute(b bool) config.Option {
+	return config.Option{F: func(o *config.Options) {
+		o.DebugPrintRoute = b
+	}}
+}

--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -289,10 +289,10 @@ func WithAutoReloadRender(b bool, interval time.Duration) config.Option {
 	}}
 }
 
-// WithDebugPrintRoute sets whether enable debugPrintRoute
-// If we don't set it, it will default to true
-func WithDebugPrintRoute(b bool) config.Option {
+// WithDisablePrintRoute sets whether disable debugPrintRoute
+// If we don't set it, it will default to false
+func WithDisablePrintRoute(b bool) config.Option {
 	return config.Option{F: func(o *config.Options) {
-		o.DebugPrintRoute = b
+		o.DisablePrintRoute = b
 	}}
 }

--- a/pkg/app/server/option_test.go
+++ b/pkg/app/server/option_test.go
@@ -47,7 +47,7 @@ func TestOptions(t *testing.T) {
 		WithStreamBody(false),
 		WithHostPorts(":8888"),
 		WithMaxRequestBodySize(2),
-		WithDebugPrintRoute(false),
+		WithDisablePrintRoute(true),
 		WithNetwork("unix"),
 		WithExitWaitTime(time.Second),
 		WithMaxKeepBodySize(500),
@@ -72,7 +72,7 @@ func TestOptions(t *testing.T) {
 	assert.DeepEqual(t, opt.StreamRequestBody, false)
 	assert.DeepEqual(t, opt.Addr, ":8888")
 	assert.DeepEqual(t, opt.MaxRequestBodySize, 2)
-	assert.DeepEqual(t, opt.DebugPrintRoute, false)
+	assert.DeepEqual(t, opt.DisablePrintRoute, true)
 	assert.DeepEqual(t, opt.Network, "unix")
 	assert.DeepEqual(t, opt.ExitWaitTimeout, time.Second)
 	assert.DeepEqual(t, opt.MaxKeepBodySize, 500)
@@ -101,7 +101,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.DeepEqual(t, opt.StreamRequestBody, false)
 	assert.DeepEqual(t, opt.Addr, ":8888")
 	assert.DeepEqual(t, opt.MaxRequestBodySize, 4*1024*1024)
-	assert.DeepEqual(t, opt.DebugPrintRoute, true)
+	assert.DeepEqual(t, opt.DisablePrintRoute, false)
 	assert.DeepEqual(t, opt.Network, "tcp")
 	assert.DeepEqual(t, opt.ExitWaitTimeout, time.Second*5)
 	assert.DeepEqual(t, opt.MaxKeepBodySize, 4*1024*1024)

--- a/pkg/app/server/option_test.go
+++ b/pkg/app/server/option_test.go
@@ -47,6 +47,7 @@ func TestOptions(t *testing.T) {
 		WithStreamBody(false),
 		WithHostPorts(":8888"),
 		WithMaxRequestBodySize(2),
+		WithDebugPrintRoute(false),
 		WithNetwork("unix"),
 		WithExitWaitTime(time.Second),
 		WithMaxKeepBodySize(500),
@@ -71,6 +72,7 @@ func TestOptions(t *testing.T) {
 	assert.DeepEqual(t, opt.StreamRequestBody, false)
 	assert.DeepEqual(t, opt.Addr, ":8888")
 	assert.DeepEqual(t, opt.MaxRequestBodySize, 2)
+	assert.DeepEqual(t, opt.DebugPrintRoute, false)
 	assert.DeepEqual(t, opt.Network, "unix")
 	assert.DeepEqual(t, opt.ExitWaitTimeout, time.Second)
 	assert.DeepEqual(t, opt.MaxKeepBodySize, 500)
@@ -99,6 +101,7 @@ func TestDefaultOptions(t *testing.T) {
 	assert.DeepEqual(t, opt.StreamRequestBody, false)
 	assert.DeepEqual(t, opt.Addr, ":8888")
 	assert.DeepEqual(t, opt.MaxRequestBodySize, 4*1024*1024)
+	assert.DeepEqual(t, opt.DebugPrintRoute, true)
 	assert.DeepEqual(t, opt.Network, "tcp")
 	assert.DeepEqual(t, opt.ExitWaitTimeout, time.Second*5)
 	assert.DeepEqual(t, opt.MaxKeepBodySize, 4*1024*1024)

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -56,6 +56,7 @@ type Options struct {
 	DisablePreParseMultipartForm bool
 	StreamRequestBody            bool
 	NoDefaultServerHeader        bool
+	DebugPrintRoute              bool
 	Network                      string
 	Addr                         string
 	ExitWaitTimeout              time.Duration
@@ -150,6 +151,10 @@ func NewOptions(opts []Option) *Options {
 		// The default is to automatically read request bodies of Expect 100 Continue requests
 		// like they are normal requests
 		DisablePreParseMultipartForm: false,
+
+		// Print logs of the routes by default
+		// Will not be printed when set to False
+		DebugPrintRoute: true,
 
 		// "tcp", "udp", "unix"(unix domain socket)
 		Network: defaultNetwork,

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -56,7 +56,7 @@ type Options struct {
 	DisablePreParseMultipartForm bool
 	StreamRequestBody            bool
 	NoDefaultServerHeader        bool
-	DebugPrintRoute              bool
+	DisablePrintRoute            bool
 	Network                      string
 	Addr                         string
 	ExitWaitTimeout              time.Duration
@@ -152,9 +152,9 @@ func NewOptions(opts []Option) *Options {
 		// like they are normal requests
 		DisablePreParseMultipartForm: false,
 
-		// Print logs of the routes by default
-		// Will not be printed when set to False
-		DebugPrintRoute: true,
+		// Routes info printing is not disabled by default
+		// Disabled when set to True
+		DisablePrintRoute: false,
 
 		// "tcp", "udp", "unix"(unix domain socket)
 		Network: defaultNetwork,

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -572,10 +572,6 @@ func debugPrintRoute(httpMethod, absolutePath string, handlers app.HandlersChain
 	hlog.Debugf("HERTZ: Method=%-6s absolutePath=%-25s --> handlerName=%s (num=%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
 }
 
-func debugPrintRouteEnable(opt *config.Options) bool {
-	return opt.DebugPrintRoute
-}
-
 func (engine *Engine) addRoute(method, path string, handlers app.HandlersChain) {
 	if len(path) == 0 {
 		panic("path should not be ''")
@@ -584,7 +580,7 @@ func (engine *Engine) addRoute(method, path string, handlers app.HandlersChain) 
 	utils.Assert(method != "", "HTTP method can not be empty")
 	utils.Assert(len(handlers) > 0, "there must be at least one handler")
 
-	if debugPrintRouteEnable(engine.options) {
+	if !engine.options.DisablePrintRoute {
 		debugPrintRoute(method, path, handlers)
 	}
 

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -572,6 +572,10 @@ func debugPrintRoute(httpMethod, absolutePath string, handlers app.HandlersChain
 	hlog.Debugf("HERTZ: Method=%-6s absolutePath=%-25s --> handlerName=%s (num=%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
 }
 
+func debugPrintRouteEnable(opt *config.Options) bool {
+	return opt.DebugPrintRoute
+}
+
 func (engine *Engine) addRoute(method, path string, handlers app.HandlersChain) {
 	if len(path) == 0 {
 		panic("path should not be ''")
@@ -580,7 +584,10 @@ func (engine *Engine) addRoute(method, path string, handlers app.HandlersChain) 
 	utils.Assert(method != "", "HTTP method can not be empty")
 	utils.Assert(len(handlers) > 0, "there must be at least one handler")
 
-	debugPrintRoute(method, path, handlers)
+	if debugPrintRouteEnable(engine.options) {
+		debugPrintRoute(method, path, handlers)
+	}
+
 	methodRouter := engine.trees.get(method)
 	if methodRouter == nil {
 		methodRouter = &router{method: method, root: &node{}, hasTsrHandler: make(map[string]bool)}


### PR DESCRIPTION
#### What type of PR is this?

optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

添加一个选项来控制是否执行 `debugPrintRoute`

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->

en: Added an option to control whether to print the route's log when it starts running, the default is to print. If **panic** occurs when there are many routes, because there is a lot of routing startup information, **panic** cannot be seen intuitively. Adding this option can avoid such a situation.

zh(optional): 新增了一个可选项来控制是否在开始运行时打印路由的日志，默认为打印。在路由较多时若发生**panic**，由于有大量的路由启动信息，因此不能直观的看到**panic**，增加此可选项后可避免此类情况出现。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #268 
