### PR TITLE
feat: add compile tag for json implementation

### DIFF
--- a/pkg/app/server/binding/binding.go
+++ b/pkg/app/server/binding/binding.go
@@ -23,13 +23,13 @@ import (
 	"github.com/bytedance/go-tagexpr/v2/binding"
 	"github.com/bytedance/go-tagexpr/v2/binding/gjson"
 	"github.com/bytedance/go-tagexpr/v2/validator"
-	"github.com/bytedance/sonic"
+	hjson "github.com/cloudwego/hertz/pkg/common/json"
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/cloudwego/hertz/pkg/route/param"
 )
 
 func init() {
-	binding.ResetJSONUnmarshaler(sonic.Unmarshal)
+	binding.ResetJSONUnmarshaler(hjson.Unmarshal)
 }
 
 var defaultBinder = binding.Default()

--- a/pkg/app/server/render/json.go
+++ b/pkg/app/server/render/json.go
@@ -45,7 +45,7 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/bytedance/sonic"
+	hjson "github.com/cloudwego/hertz/pkg/common/json"
 	"github.com/cloudwego/hertz/pkg/protocol"
 )
 
@@ -55,7 +55,7 @@ type JSONMarshaler func(v interface{}) ([]byte, error)
 var jsonMarshalFunc JSONMarshaler
 
 func init() {
-	ResetJSONMarshal(sonic.Marshal)
+	ResetJSONMarshal(hjson.Marshal)
 }
 
 func ResetJSONMarshal(fn JSONMarshaler) {

--- a/pkg/common/bytebufferpool/bytebuffer.go
+++ b/pkg/common/bytebufferpool/bytebuffer.go
@@ -51,7 +51,6 @@ import "io"
 //
 // Use Get for obtaining an empty byte buffer.
 type ByteBuffer struct {
-
 	// B is a byte buffer to use in append-like workloads.
 	// See example code for details.
 	B []byte

--- a/pkg/common/json/sonic.go
+++ b/pkg/common/json/sonic.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//go:build (linux || windows || darwin) && amd64
+// +build linux windows darwin
+// +build amd64
+
+package json
+
+import "github.com/bytedance/sonic"
+
+// Name is the name of the effective json package.
+const Name = "sonic"
+
+var (
+	json = sonic.ConfigStd
+	// Marshal is sonic implementation exported by hertz which is used by rendering.
+	Marshal = json.Marshal
+	// Unmarshal is sonic implementation exported by hertz which is used by binding.
+	Unmarshal = json.Unmarshal
+	// MarshalIndent is sonic implementation exported by hertz.
+	MarshalIndent = json.MarshalIndent
+	// NewDecoder is sonic implementation exported by hertz.
+	NewDecoder = json.NewDecoder
+	// NewEncoder is sonic implementation exported by hertz.
+	NewEncoder = json.NewEncoder
+)

--- a/pkg/common/json/std.go
+++ b/pkg/common/json/std.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//go:build stdjson || !(amd64 && (linux || windows || darwin))
+// +build stdjson !amd64 !linux,!windows,!darwin
+
+package json
+
+import "encoding/json"
+
+// Name is the name of the effective json package.
+const Name = "encoding/json"
+
+var (
+	// Marshal is standard implementation exported by hertz which is used by rendering.
+	Marshal = json.Marshal
+	// Unmarshal is standard implementation exported by hertz which is used by binding.
+	Unmarshal = json.Unmarshal
+	// MarshalIndent is standard implementation exported by hertz.
+	MarshalIndent = json.MarshalIndent
+	// NewDecoder is standard implementation exported by hertz.
+	NewDecoder = json.NewDecoder
+	// NewEncoder is standard implementation exported by hertz.
+	NewEncoder = json.NewEncoder
+)

--- a/pkg/protocol/http1/req/request_test.go
+++ b/pkg/protocol/http1/req/request_test.go
@@ -1120,7 +1120,8 @@ func testContinueReadBodyStream(t *testing.T, header, body string, maxBodySize, 
 }
 
 func verifyRequestHeader(t *testing.T, h *protocol.RequestHeader, expectedContentLength int,
-	expectedRequestURI, expectedHost, expectedReferer, expectedContentType string) {
+	expectedRequestURI, expectedHost, expectedReferer, expectedContentType string,
+) {
 	if h.ContentLength() != expectedContentLength {
 		t.Fatalf("Unexpected Content-Length %d. Expected %d", h.ContentLength(), expectedContentLength)
 	}

--- a/pkg/protocol/http1/resp/response_test.go
+++ b/pkg/protocol/http1/resp/response_test.go
@@ -159,7 +159,8 @@ func testResponseReadError(t *testing.T, resp *protocol.Response, response strin
 }
 
 func testResponseReadSuccess(t *testing.T, resp *protocol.Response, response string, expectedStatusCode, expectedContentLength int,
-	expectedContentType, expectedBody, expectedTrailer string) {
+	expectedContentType, expectedBody, expectedTrailer string,
+) {
 	zr := mock.NewZeroCopyReader(response)
 	err := Read(resp, zr)
 	if err != nil {
@@ -436,7 +437,8 @@ func verifyResponseHeader(t *testing.T, h *protocol.ResponseHeader, expectedStat
 }
 
 func testResponseSuccess(t *testing.T, statusCode int, contentType, serverName, body string,
-	expectedStatusCode int, expectedContentType, expectedServerName string) {
+	expectedStatusCode int, expectedContentType, expectedServerName string,
+) {
 	var resp protocol.Response
 	resp.SetStatusCode(statusCode)
 	resp.Header.Set("Content-Type", contentType)
@@ -479,7 +481,8 @@ func testResponseSuccess(t *testing.T, statusCode int, contentType, serverName, 
 }
 
 func testResponseReadWithoutBody(t *testing.T, resp *protocol.Response, s string, skipBody bool,
-	expectedStatusCode, expectedContentLength int, expectedContentType, expectedTrailer string) {
+	expectedStatusCode, expectedContentLength int, expectedContentType, expectedTrailer string,
+) {
 	zr := mock.NewZeroCopyReader(s)
 	resp.SkipBody = skipBody
 	err := Read(resp, zr)


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
增加编译tag控制实际使用的json库

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: Add compile tag for json implementation. Sonic is still used by default, but with a cpu compile check. And its available for users to change the default json lib(sonic) to standard json lib through compile tag: `stdjson`
zh(optional): 增加编译tag控制json库的选择。Sonic仍然作为默认实现，不过增加了cpu检测（针对不符合sonic要求的cpu自动切换至标准json库）。同时新增了一个编译tag：`stdjson` 用于主动切换到标准json实现

#### Which issue(s) this PR fixes:
A better solution to #277 