### PR TITLE
fix: potential edge bugs of retry

### DIFF
--- a/pkg/app/client/retry/retry.go
+++ b/pkg/app/client/retry/retry.go
@@ -62,18 +62,16 @@ func FixedDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	return retryConfig.Delay
 }
 
-// RandomDelayPolicy is a DelayPolicyFunc which picks a random delay up toRetryConfig.MaxJitter
+// RandomDelayPolicy is a DelayPolicyFunc which picks a random delay up to RetryConfig.MaxJitter,if the MaxJitter <= 0 then return 0 , prevent random number generator panic
 func RandomDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
-	// When the MaxJitter <= 0 return 0 , prevent random number generator panic
 	if retryConfig.MaxJitter <= 0 {
 		return 0 * time.Millisecond
 	}
 	return time.Duration(fastrand.Int63n(int64(retryConfig.MaxJitter)))
 }
 
-// BackOffDelayPolicy is a DelayPolicyFunc which exponentially increases delay between consecutive retries
+// BackOffDelayPolicy is a DelayPolicyFunc which exponentially increases delay between consecutive retries,if the InitDelay <= 0 then return 0 , prevent negative number left shift
 func BackOffDelayPolicy(attempts uint, _ error, retryConfig *Config) time.Duration {
-	// When the MaxJitter <= 0 return 0 , prevent negative number left shift
 	if retryConfig.Delay <= 0 {
 		return 0 * time.Millisecond
 	}
@@ -103,9 +101,8 @@ func CombineDelay(delays ...DelayPolicyFunc) DelayPolicyFunc {
 	}
 }
 
-// Delay generate the delay time required for the current retry
+// Delay generate the delay time required for the current retry config , if retryConfig.DelayPolicy == nil then return 0 , prevent nil pointer panic
 func Delay(attempts uint, err error, retryConfig *Config) time.Duration {
-	// Directly return 0 if retryConfig.DelayPolicy is nil , prevent nil pointer panic
 	if retryConfig.DelayPolicy == nil {
 		return 0 * time.Millisecond
 	}

--- a/pkg/app/client/retry/retry.go
+++ b/pkg/app/client/retry/retry.go
@@ -62,7 +62,7 @@ func FixedDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	return retryConfig.Delay
 }
 
-// RandomDelayPolicy is a DelayPolicyFunc which picks a random delay up to RetryConfig.MaxJitter,if the MaxJitter <= 0 then return 0 , prevent random number generator panic
+// RandomDelayPolicy is a DelayPolicyFunc which picks a random delay up to RetryConfig.MaxJitter, if the retryConfig.MaxJitter less than or equal to 0 , the final delay is 0
 func RandomDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	if retryConfig.MaxJitter <= 0 {
 		return 0 * time.Millisecond
@@ -70,7 +70,7 @@ func RandomDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	return time.Duration(fastrand.Int63n(int64(retryConfig.MaxJitter)))
 }
 
-// BackOffDelayPolicy is a DelayPolicyFunc which exponentially increases delay between consecutive retries,if the InitDelay <= 0 then return 0 , prevent negative number left shift
+// BackOffDelayPolicy is a DelayPolicyFunc which exponentially increases delay between consecutive retries, if the retryConfig.Delay less than or equal to 0 , the final delay is 0
 func BackOffDelayPolicy(attempts uint, _ error, retryConfig *Config) time.Duration {
 	if retryConfig.Delay <= 0 {
 		return 0 * time.Millisecond
@@ -101,7 +101,7 @@ func CombineDelay(delays ...DelayPolicyFunc) DelayPolicyFunc {
 	}
 }
 
-// Delay generate the delay time required for the current retry config , if retryConfig.DelayPolicy == nil then return 0 , prevent nil pointer panic
+// Delay generate the delay time required for the current retry config , if the retryConfig.DelayPolicy == nil , the final delay is 0
 func Delay(attempts uint, err error, retryConfig *Config) time.Duration {
 	if retryConfig.DelayPolicy == nil {
 		return 0 * time.Millisecond

--- a/pkg/app/client/retry/retry.go
+++ b/pkg/app/client/retry/retry.go
@@ -62,7 +62,7 @@ func FixedDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	return retryConfig.Delay
 }
 
-// RandomDelayPolicy is a DelayPolicyFunc which picks a random delay up to RetryConfig.MaxJitter, if the retryConfig.MaxJitter less than or equal to 0 , the final delay is 0
+// RandomDelayPolicy is a DelayPolicyFunc which picks a random delay up to RetryConfig.MaxJitter, if the retryConfig.MaxJitter less than or equal to 0, the final delay is 0
 func RandomDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	if retryConfig.MaxJitter <= 0 {
 		return 0 * time.Millisecond
@@ -70,7 +70,7 @@ func RandomDelayPolicy(_ uint, _ error, retryConfig *Config) time.Duration {
 	return time.Duration(fastrand.Int63n(int64(retryConfig.MaxJitter)))
 }
 
-// BackOffDelayPolicy is a DelayPolicyFunc which exponentially increases delay between consecutive retries, if the retryConfig.Delay less than or equal to 0 , the final delay is 0
+// BackOffDelayPolicy is a DelayPolicyFunc which exponentially increases delay between consecutive retries, if the retryConfig.Delay less than or equal to 0, the final delay is 0
 func BackOffDelayPolicy(attempts uint, _ error, retryConfig *Config) time.Duration {
 	if retryConfig.Delay <= 0 {
 		return 0 * time.Millisecond
@@ -101,7 +101,7 @@ func CombineDelay(delays ...DelayPolicyFunc) DelayPolicyFunc {
 	}
 }
 
-// Delay generate the delay time required for the current retry config , if the retryConfig.DelayPolicy == nil , the final delay is 0
+// Delay generate the delay time required for the current retry config, if the retryConfig.DelayPolicy == nil, the final delay is 0
 func Delay(attempts uint, err error, retryConfig *Config) time.Duration {
 	if retryConfig.DelayPolicy == nil {
 		return 0 * time.Millisecond

--- a/pkg/app/client/retry/retry.go
+++ b/pkg/app/client/retry/retry.go
@@ -27,6 +27,7 @@ import (
 type Config struct {
 	// The maximum number of call attempt times, including the initial call
 	MaxAttemptTimes uint
+
 	// Initial retry delay time
 	Delay time.Duration
 


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复retry潜在的bug

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
1. In the case of the direct initialization definition &http1. HostClient {} in the picture, when the number of retries is greater than 1, the delay time will be calculated, but the retryConfig. DelayPolicy of retryConfig is nil, and when the retryConfig. DelayPolicy function is executed, a nil pointer error will be reported
2. When the MaxJitter of retryConfig is 0, a panic will occur when using retry.RandomDelayPolicy to generate random numbers
3. The negative number moves to the left will become very large, which is unreasonable

zh(optional):
1.图片中直接初始化定义&http1.HostClient{}的情况，retry次数大于1时，就会计算延迟时间，但retryConfig的retryConfig.DelayPolicy为nil，这时候执行retryConfig.DelayPolicy函数就会报空指针错误
2.在retryConfig的MaxJitter为0时，使用retry.RandomDelayPolicy生成随机数时会panic
3.负数左移会变的特别大，不合理
![image](https://user-images.githubusercontent.com/58356743/192976351-95c27ea8-0ccc-4eb9-8cb6-ee5aac4e9858.png)


#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
