### PR TITLE
optimize: ignore flushing error when connection is closed or reset

### DIFF
--- a/pkg/network/netpoll/connection.go
+++ b/pkg/network/netpoll/connection.go
@@ -22,6 +22,8 @@ package netpoll
 import (
 	"errors"
 	"io"
+	"strings"
+	"syscall"
 
 	"github.com/cloudwego/hertz/pkg/common/hlog"
 	"github.com/cloudwego/hertz/pkg/network"
@@ -75,8 +77,12 @@ func (c *Conn) Flush() error {
 }
 
 func (c *Conn) HandleSpecificError(err error, rip string) (needIgnore bool) {
-	if errors.Is(err, netpoll.ErrConnClosed) {
-		hlog.SystemLogger().Warnf("Netpoll error=%s, remoteAddr=%s", err.Error(), rip)
+	if errors.Is(err, netpoll.ErrConnClosed) || errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
+		// ignore flushing error when connection is closed or reset
+		if strings.Contains(err.Error(), "when flush") {
+			return true
+		}
+		hlog.SystemLogger().Debugf("Netpoll error=%s, remoteAddr=%s", err.Error(), rip)
 		return true
 	}
 	return false


### PR DESCRIPTION
#### What type of PR is this?
optimize


#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
忽略客户端主动断连的写错误

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: change logs level from error to debug if those are the connection error caused by client
zh(optional): 将client导致的连接错误日志级别从error调整为debug，进一步减少对用户的打扰信息

#### Which issue(s) this PR fixes:
None