### PR TITLE
optimize: A new optimization for simplifying writing UT file.

### DIFF
--- a/pkg/common/ut/ping.go
+++ b/pkg/common/ut/ping.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package ut provides a convenient way to write unit test for the business logic.
+
+package ut
+
+import (
+	"context"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/common/utils"
+)
+
+// Ping .
+func Ping(ctx context.Context, c *app.RequestContext) {
+	c.JSON(200, utils.H{
+		"message": "pong",
+	})
+}

--- a/pkg/common/ut/request.go
+++ b/pkg/common/ut/request.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/cloudwego/hertz/pkg/app/server"
 	"github.com/cloudwego/hertz/pkg/protocol"
 	"github.com/cloudwego/hertz/pkg/route"
 )
@@ -87,4 +88,9 @@ func PerformRequest(engine *route.Engine, method, url string, body *Body, header
 	w.Write(ctx.Response.Body())
 	w.Flush()
 	return w
+}
+
+func PerformBizServerRequest(bizServer *server.Hertz, method, url string, body *Body, headers ...Header) *ResponseRecorder {
+	engine := bizServer.Engine
+	return PerformRequest(engine, method, url, body, headers...)
 }

--- a/pkg/common/ut/request.go
+++ b/pkg/common/ut/request.go
@@ -90,6 +90,22 @@ func PerformRequest(engine *route.Engine, method, url string, body *Body, header
 	return w
 }
 
+// PerformBizServerRequest calls the PerformRequest function with only one difference. It use server as the first parameter,
+//
+// instead of engine.
+//
+// Using this function, we will not need to implement router's logic again in the UT file. The same logic is already
+//
+// in the handler file.
+//
+// Every time the handler updates, there's no need to copy and pace biz logic code to UT again.
+//
+// Example usage:
+//
+// h := server.Default()
+// h.GET("/ping", handler.Ping) # here is your handler
+//
+// Pass this h to PerformBizServerRequest in the first place.
 func PerformBizServerRequest(bizServer *server.Hertz, method, url string, body *Body, headers ...Header) *ResponseRecorder {
 	engine := bizServer.Engine
 	return PerformRequest(engine, method, url, body, headers...)

--- a/pkg/common/ut/request_test.go
+++ b/pkg/common/ut/request_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/cloudwego/hertz/pkg/app"
+	"github.com/cloudwego/hertz/pkg/app/server"
 	"github.com/cloudwego/hertz/pkg/common/config"
 	"github.com/cloudwego/hertz/pkg/common/test/assert"
 	"github.com/cloudwego/hertz/pkg/route"
@@ -115,4 +116,14 @@ func createChunkedBody(body []byte) []byte {
 		chunkSize++
 	}
 	return append(b, []byte("0\r\n\r\n")...)
+}
+
+func TestPerformBizServerRequest(t *testing.T) {
+	h := server.Default()
+	h.GET("/ping", Ping)
+	w := PerformBizServerRequest(h, "GET", "/ping", &Body{bytes.NewBufferString("1"), 1},
+		Header{"Connection", "close"})
+	resp := w.Result()
+	assert.DeepEqual(t, 201, resp.StatusCode())
+	assert.DeepEqual(t, "{\"message\":\"pong\"}", string(resp.Body()))
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

optimize: A new optimization for simplifying writing UT file.
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
简化单测文件编写流程，避免在单测文件中重写handler里出现过的业务逻辑

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
![image](https://user-images.githubusercontent.com/1081377/198536770-06d30967-d25d-4601-ab42-ab848e258864.png)
As shown in the picture from Hertz example, those logic code should already be in the handler file. For the *_test.go UT file, it's not a good practice to copy and pace those code again. Every time we change the handler file, we need to copy again into test file.
Using this PR fix, we can write UT in the way below:
![image](https://user-images.githubusercontent.com/1081377/198537497-209a8edd-5d5d-4fd0-abd6-6fd217c850d2.png)
There is no need to copy logic code again now.

zh(optional):
![image](https://user-images.githubusercontent.com/1081377/198536770-06d30967-d25d-4601-ab42-ab848e258864.png)
从Hertz的示例代码中可以看到，为了写单元测试代码，需要将接口逻辑在单测函数中重写一遍，但是如果接口逻辑改过了，单测文件中也需要重新复制粘贴一遍，较为麻烦。
通过本PR改动，可以用下面的示例方法来写单测：
![image](https://user-images.githubusercontent.com/1081377/198537497-209a8edd-5d5d-4fd0-abd6-6fd217c850d2.png)
不再需要复制粘贴业务逻辑代码。
#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
