### PR TITLE
feat: distinguish between global and local transporter

### DIFF
--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/tracer/stats"
 	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/hertz/pkg/network/standard"
-	"github.com/cloudwego/hertz/pkg/route"
 )
 
 // WithKeepAliveTimeout sets keep-alive timeout.
@@ -216,7 +215,7 @@ func WithExitWaitTime(timeout time.Duration) config.Option {
 // NOTE: If a tls server is started, it won't accept non-tls request.
 func WithTLS(cfg *tls.Config) config.Option {
 	return config.Option{F: func(o *config.Options) {
-		route.SetTransporter(standard.NewTransporter)
+		o.TransporterNewer = standard.NewTransporter
 		o.TLS = cfg
 	}}
 }
@@ -231,7 +230,7 @@ func WithListenConfig(l *net.ListenConfig) config.Option {
 // WithTransport sets which network library to use.
 func WithTransport(transporter func(options *config.Options) network.Transporter) config.Option {
 	return config.Option{F: func(o *config.Options) {
-		route.SetTransporter(transporter)
+		o.TransporterNewer = transporter
 	}}
 }
 

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/app/server/registry"
+	"github.com/cloudwego/hertz/pkg/network"
 )
 
 // Option is the only struct that can be used to set Options.
@@ -68,11 +69,15 @@ type Options struct {
 	TraceLevel                   interface{}
 	ListenConfig                 *net.ListenConfig
 
+	// TransporterNewer is the function to create a transporter.
+	TransporterNewer func(opt *Options) network.Transporter
+
 	// Registry is used for service registry.
 	Registry registry.Registry
 	// RegistryInfo is base info used for service registry.
 	RegistryInfo *registry.Info
 	// Enable automatically HTML template reloading mechanism.
+
 	AutoReloadRender bool
 	// If AutoReloadInterval is set to 0(default).
 	// The HTML template will reload according to files' changing event

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -76,6 +76,8 @@ import (
 	"github.com/cloudwego/hertz/pkg/protocol/suite"
 )
 
+const unknownTransporterName = "unknown"
+
 var (
 	defaultTransporter = standard.NewTransporter
 
@@ -199,15 +201,35 @@ func (engine *Engine) GetOptions() *config.Options {
 	return engine.options
 }
 
+// SetTransporter only sets the global default value for the transporter.
+// Use WithTransporter during engine creation to set the transporter for the engine.
 func SetTransporter(transporter func(options *config.Options) network.Transporter) {
 	defaultTransporter = transporter
 }
 
+func (engine *Engine) GetTransporterName() (tName string) {
+	return getTransporterName(engine.transport)
+}
+
+func getTransporterName(transporter network.Transporter) (tName string) {
+	defer func() {
+		err := recover()
+		if err != nil || tName == "" {
+			tName = unknownTransporterName
+		}
+	}()
+	t := reflect.ValueOf(transporter).Type().String()
+	tName = strings.Split(strings.TrimPrefix(t, "*"), ".")[0]
+	return tName
+}
+
+// Deprecated: This only get the global default transporter - may not be the real one used by the engine.
+// Use engine.GetTransporterName for the real transporter used.
 func GetTransporterName() (tName string) {
 	defer func() {
 		err := recover()
-		if err != nil {
-			tName = "unknown"
+		if err != nil || tName == "" {
+			tName = unknownTransporterName
 		}
 	}()
 	fName := runtime.FuncForPC(reflect.ValueOf(defaultTransporter).Pointer()).Name()
@@ -363,7 +385,7 @@ func (engine *Engine) alpnEnable() bool {
 }
 
 func (engine *Engine) listenAndServe() error {
-	hlog.SystemLogger().Infof("Using network library=%s", GetTransporterName())
+	hlog.SystemLogger().Infof("Using network library=%s", engine.GetTransporterName())
 	return engine.transport.ListenAndServe(engine.onData)
 }
 
@@ -519,6 +541,9 @@ func NewEngine(opt *config.Options) *Engine {
 		protocolServers: make(map[string]protocol.Server),
 		enableTrace:     true,
 		options:         opt,
+	}
+	if opt.TransporterNewer != nil {
+		engine.transport = opt.TransporterNewer(opt)
 	}
 	engine.RouterGroup.engine = engine
 

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -64,11 +64,31 @@ import (
 )
 
 func TestNew_Engine(t *testing.T) {
+	defaultTransporter = standard.NewTransporter
 	opt := config.NewOptions([]config.Option{})
 	router := NewEngine(opt)
+	assert.DeepEqual(t, "standard", router.GetTransporterName())
 	assert.DeepEqual(t, "/", router.basePath)
 	assert.DeepEqual(t, router.engine, router)
 	assert.DeepEqual(t, 0, len(router.Handlers))
+}
+
+func TestNew_Engine_WithTransporter(t *testing.T) {
+	defaultTransporter = netpoll.NewTransporter
+	opt := config.NewOptions([]config.Option{})
+	router := NewEngine(opt)
+	assert.DeepEqual(t, "netpoll", router.GetTransporterName())
+
+	defaultTransporter = netpoll.NewTransporter
+	opt.TransporterNewer = standard.NewTransporter
+	router = NewEngine(opt)
+	assert.DeepEqual(t, "standard", router.GetTransporterName())
+	assert.DeepEqual(t, "netpoll", GetTransporterName())
+}
+
+func TestGetTransporterName(t *testing.T) {
+	name := getTransporterName(&fakeTransporter{})
+	assert.DeepEqual(t, "route", name)
 }
 
 func TestEngineUnescape(t *testing.T) {
@@ -522,5 +542,22 @@ func (m *mockConn) WriteBinary(b []byte) (n int, err error) {
 }
 
 func (m *mockConn) Flush() error {
+	panic("implement me")
+}
+
+type fakeTransporter struct{}
+
+func (f *fakeTransporter) Close() error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *fakeTransporter) Shutdown(ctx context.Context) error {
+	// TODO implement me
+	panic("implement me")
+}
+
+func (f *fakeTransporter) ListenAndServe(onData network.OnData) error {
+	// TODO implement me
 	panic("implement me")
 }


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
server 区分局部和全局 transporter

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: change transporter of the hertz instance with option will not effect global transporter, vice versa. Avoid potential problems affecting other instances by modifying the transporter.
zh(optional): 修改 hertz 实例的 transporter 不会影响全局默认的 transporter，反之亦然；避免潜在的因为修改 transporter 导致影响到其他实例的问题。

#### Which issue(s) this PR fixes:
None