### PR TITLE
optimize: zero idle timeout acts the same

### DIFF
--- a/pkg/common/test/mock/network.go
+++ b/pkg/common/test/mock/network.go
@@ -61,6 +61,10 @@ func (m *Conn) Release() error {
 func (m *Conn) Peek(i int) ([]byte, error) {
 	b, err := m.zr.Peek(i)
 	if err != nil || len(b) != i {
+		if m.readTimeout <= 0 {
+			// simulate timeout forever
+			select {}
+		}
 		time.Sleep(m.readTimeout)
 		return nil, errs.ErrTimeout
 	}

--- a/pkg/protocol/http1/server.go
+++ b/pkg/protocol/http1/server.go
@@ -330,7 +330,8 @@ func (s Server) Serve(c context.Context, conn network.Conn) (err error) {
 		if connectionClose {
 			return errShortConnection
 		}
-
+		// Back to network layer to trigger.
+		// For now, only netpoll network mode has this feature.
 		if s.IdleTimeout == 0 {
 			return
 		}

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -954,7 +954,7 @@ func iterate(method string, routes RoutesInfo, root *node) RoutesInfo {
 
 // for built-in http1 impl only.
 func newHttp1OptionFromEngine(engine *Engine) *http1.Option {
-	return &http1.Option{
+	opt := &http1.Option{
 		StreamRequestBody:            engine.options.StreamRequestBody,
 		GetOnly:                      engine.options.GetOnly,
 		DisablePreParseMultipartForm: engine.options.DisablePreParseMultipartForm,
@@ -970,4 +970,10 @@ func newHttp1OptionFromEngine(engine *Engine) *http1.Option {
 		EnableTrace:                  engine.IsTraceEnable(),
 		HijackConnHandle:             engine.HijackConnHandle,
 	}
+	// Idle timeout of standard network must not be zero. Set it to -1 seconds if it is zero.
+	// Due to the different triggering ways of the network library, see the actual use of this value for the detailed reasons.
+	if opt.IdleTimeout == 0 && engine.GetTransporterName() == "standard" {
+		opt.IdleTimeout = -1
+	}
+	return opt
 }


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
设置 idle timeout 为 0 在不同的网络库下行为一致

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: before this, standard network cannot process requests properly when idle timeout is set to zero, this may be confusing to users. 
zh(optional): 在此之前，标准网络在空闲超时设置为零时无法正确处理请求，这可能会让用户感到困惑。

#### Which issue(s) this PR fixes:
None