### PR TITLE
feat: add round_robin and weight_round_robin algorithm for loadbalance

### DIFF
--- a/pkg/app/client/loadbalance/round_robin.go
+++ b/pkg/app/client/loadbalance/round_robin.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalance
+
+import (
+	"sync"
+
+	"github.com/cloudwego/hertz/pkg/app/client/discovery"
+	"golang.org/x/sync/singleflight"
+)
+
+type roundRobinBalancer struct {
+	cachedInfo sync.Map
+	sfg        singleflight.Group
+}
+
+type roundRobinInfo struct {
+	instances []discovery.Instance
+	index     int
+}
+
+// NewRoundRobinBalancer creates a loadbalancer using round-robin algorithm.
+func NewRoundRobinBalancer() Loadbalancer {
+	lb := &roundRobinBalancer{}
+	return lb
+}
+
+// Pick implements the Loadbalancer interface.
+func (rr *roundRobinBalancer) Pick(e discovery.Result) discovery.Instance {
+	ri, ok := rr.cachedInfo.Load(e.CacheKey)
+	if !ok {
+		ri, _, _ = rr.sfg.Do(e.CacheKey, func() (interface{}, error) {
+			return &roundRobinInfo{
+				instances: e.Instances,
+				index:     0,
+			}, nil
+		})
+		rr.cachedInfo.Store(e.CacheKey, ri)
+	}
+
+	r := ri.(*roundRobinInfo)
+	if len(r.instances) == 0 {
+		return nil
+	}
+
+	lens := len(r.instances)
+	if r.index >= lens {
+		r.index = 0
+	}
+
+	instance := r.instances[r.index]
+	r.index = (r.index + 1) % lens
+
+	return instance
+}
+
+// Rebalance implements the Loadbalancer interface.
+func (rr *roundRobinBalancer) Rebalance(e discovery.Result) {
+	rr.cachedInfo.Store(e.CacheKey, &roundRobinInfo{
+		instances: e.Instances,
+		index:     0,
+	})
+}
+
+// Delete implements the Loadbalancer interface.
+func (rr *roundRobinBalancer) Delete(cacheKey string) {
+	rr.cachedInfo.Delete(cacheKey)
+}
+
+// Name implements the Loadbalancer interface.
+func (rr *roundRobinBalancer) Name() string {
+	return "round_robin"
+}

--- a/pkg/app/client/loadbalance/round_robin_test.go
+++ b/pkg/app/client/loadbalance/round_robin_test.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalance
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app/client/discovery"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+)
+
+func TestRoundRobinBalancer(t *testing.T) {
+	balancer := NewRoundRobinBalancer()
+	// nil
+	ins := balancer.Pick(discovery.Result{})
+	assert.DeepEqual(t, ins, nil)
+	// test Name()
+	assert.DeepEqual(t, "round_robin", balancer.Name())
+
+	// empty instance
+	e := discovery.Result{
+		Instances: make([]discovery.Instance, 0),
+		CacheKey:  "a",
+	}
+	balancer.Rebalance(e)
+	ins = balancer.Pick(e)
+	assert.DeepEqual(t, ins, nil)
+
+	// one instance
+	insList := []discovery.Instance{
+		discovery.NewInstance("tcp", "127.0.0.1:8888", 0, nil),
+	}
+	e = discovery.Result{
+		Instances: insList,
+		CacheKey:  "b",
+	}
+	balancer.Rebalance(e)
+	for i := 0; i < 100; i++ {
+		ins = balancer.Pick(e)
+		assert.DeepEqual(t, "127.0.0.1:8888", ins.Address().String())
+	}
+
+	// multi instances, weightSum > 0
+	insList = []discovery.Instance{
+		discovery.NewInstance("tcp", "127.0.0.1:8880", 0, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8881", 0, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8882", 0, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8883", 0, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8884", 0, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8885", 0, nil),
+	}
+
+	n := 10000
+	e = discovery.Result{
+		Instances: insList,
+		CacheKey:  "c",
+	}
+	balancer.Rebalance(e)
+	for i := 0; i < n; i++ {
+		ins = balancer.Pick(e)
+		addr := ins.Address()
+		expectedAddr := "127.0.0.1:888" + strconv.Itoa(i%6)
+		assert.DeepEqual(t, expectedAddr, addr.String())
+	}
+}

--- a/pkg/app/client/loadbalance/weight_round_robin.go
+++ b/pkg/app/client/loadbalance/weight_round_robin.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalance
+
+import (
+	"sync"
+
+	"github.com/cloudwego/hertz/pkg/app/client/discovery"
+	"github.com/cloudwego/hertz/pkg/common/hlog"
+	"golang.org/x/sync/singleflight"
+)
+
+type weightRoundRobinBalancer struct {
+	cachedInfo sync.Map
+	sfg        singleflight.Group
+}
+
+type weightRoundRobinInfo struct {
+	instances       []discovery.Instance
+	entries         []int
+	effectiveWeight []int
+	currentWeight   []int
+	weightSum       int
+}
+
+// NewWeightRoundRobinBalancer creates a loadbalancer using round-robin algorithm.
+func NewWeightRoundRobinBalancer() Loadbalancer {
+	lb := &weightRoundRobinBalancer{}
+	return lb
+}
+
+func (rr *weightRoundRobinBalancer) calcWeightInfo(e discovery.Result) *weightRoundRobinInfo {
+	w := &weightRoundRobinInfo{
+		instances:       make([]discovery.Instance, len(e.Instances)),
+		entries:         make([]int, len(e.Instances)),
+		effectiveWeight: make([]int, len(e.Instances)),
+		currentWeight:   make([]int, len(e.Instances)),
+		weightSum:       0,
+	}
+
+	var cnt int
+
+	for idx := range e.Instances {
+		weight := e.Instances[idx].Weight()
+		if weight > 0 {
+			w.instances[cnt] = e.Instances[idx]
+			w.entries[cnt] = weight
+			w.effectiveWeight[cnt] = weight
+			w.currentWeight[cnt] = 0
+			w.weightSum += weight
+			cnt++
+		} else {
+			hlog.SystemLogger().Warnf("Invalid weight=%d on instance address=%s", weight, e.Instances[idx].Address())
+		}
+	}
+
+	w.instances = w.instances[:cnt]
+
+	return w
+}
+
+// Pick implements the Loadbalancer interface.
+func (rr *weightRoundRobinBalancer) Pick(e discovery.Result) discovery.Instance {
+	ri, ok := rr.cachedInfo.Load(e.CacheKey)
+	if !ok {
+		ri, _, _ = rr.sfg.Do(e.CacheKey, func() (interface{}, error) {
+			return rr.calcWeightInfo(e), nil
+		})
+		rr.cachedInfo.Store(e.CacheKey, ri)
+	}
+
+	r := ri.(*weightRoundRobinInfo)
+	if r.weightSum <= 0 {
+		return nil
+	}
+
+	var bestIdx int
+	for idx := range e.Instances {
+		r.currentWeight[idx] += r.effectiveWeight[idx]
+		// Pick the index with the biggest weight
+		if r.currentWeight[bestIdx] < r.currentWeight[idx] {
+			bestIdx = idx
+		}
+	}
+
+	if r.instances[bestIdx] == nil {
+		return nil
+	}
+
+	r.currentWeight[bestIdx] -= r.weightSum
+	return e.Instances[bestIdx]
+}
+
+// Rebalance implements the Loadbalancer interface.
+func (rr *weightRoundRobinBalancer) Rebalance(e discovery.Result) {
+	rr.cachedInfo.Store(e.CacheKey, rr.calcWeightInfo(e))
+}
+
+// Delete implements the Loadbalancer interface.
+func (rr *weightRoundRobinBalancer) Delete(cacheKey string) {
+	rr.cachedInfo.Delete(cacheKey)
+}
+
+// Name implements the Loadbalancer interface.
+func (rr *weightRoundRobinBalancer) Name() string {
+	return "weight_round_robin"
+}

--- a/pkg/app/client/loadbalance/weight_round_robin_test.go
+++ b/pkg/app/client/loadbalance/weight_round_robin_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loadbalance
+
+import (
+	"math"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/app/client/discovery"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+)
+
+func TestWeightRoundRobinBalancer(t *testing.T) {
+	balancer := NewWeightRoundRobinBalancer()
+	// nil
+	ins := balancer.Pick(discovery.Result{})
+	assert.DeepEqual(t, ins, nil)
+	// test Name()
+	assert.DeepEqual(t, "weight_round_robin", balancer.Name())
+
+	// empty instance
+	e := discovery.Result{
+		Instances: make([]discovery.Instance, 0),
+		CacheKey:  "a",
+	}
+	balancer.Rebalance(e)
+	ins = balancer.Pick(e)
+	assert.DeepEqual(t, ins, nil)
+
+	// one instance
+	insList := []discovery.Instance{
+		discovery.NewInstance("tcp", "127.0.0.1:8888", 20, nil),
+	}
+	e = discovery.Result{
+		Instances: insList,
+		CacheKey:  "b",
+	}
+	balancer.Rebalance(e)
+	for i := 0; i < 100; i++ {
+		ins = balancer.Pick(e)
+		assert.DeepEqual(t, ins.Weight(), 20)
+	}
+
+	// multi instances, weightSum > 0
+	insList = []discovery.Instance{
+		discovery.NewInstance("tcp", "127.0.0.1:8881", 10, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8882", 20, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8883", 50, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8884", 100, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8885", 200, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8886", 500, nil),
+	}
+
+	var weightSum int
+	for _, ins := range insList {
+		weight := ins.Weight()
+		weightSum += weight
+	}
+
+	n := 10000000
+	pickedStat := map[int]int{}
+	e = discovery.Result{
+		Instances: insList,
+		CacheKey:  "c",
+	}
+	balancer.Rebalance(e)
+	for i := 0; i < n; i++ {
+		ins = balancer.Pick(e)
+		weight := ins.Weight()
+		if pickedCnt, ok := pickedStat[weight]; ok {
+			pickedStat[weight] = pickedCnt + 1
+		} else {
+			pickedStat[weight] = 1
+		}
+	}
+
+	for _, ins := range insList {
+		weight := ins.Weight()
+		expect := float64(weight) / float64(weightSum) * float64(n)
+		actual := float64(pickedStat[weight])
+		delta := math.Abs(expect - actual)
+		assert.DeepEqual(t, true, delta/expect < 0.01)
+	}
+
+	// have instances that weight < 0
+	insList = []discovery.Instance{
+		discovery.NewInstance("tcp", "127.0.0.1:8881", 10, nil),
+		discovery.NewInstance("tcp", "127.0.0.1:8882", -10, nil),
+	}
+	e = discovery.Result{
+		Instances: insList,
+		CacheKey:  "d",
+	}
+	balancer.Rebalance(e)
+	for i := 0; i < 1000; i++ {
+		ins = balancer.Pick(e)
+		assert.DeepEqual(t, 10, ins.Weight())
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

为负载均衡增加轮询以及加权轮询算法

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
Instance
```go
insList := []discovery.Instance{
    discovery.NewInstance("tcp", "127.0.0.1:8881", 10, nil),
    discovery.NewInstance("tcp", "127.0.0.1:8882", 20, nil),
    discovery.NewInstance("tcp", "127.0.0.1:8883", 50, nil),
    discovery.NewInstance("tcp", "127.0.0.1:8884", 100, nil),
    discovery.NewInstance("tcp", "127.0.0.1:8885", 200, nil),
    discovery.NewInstance("tcp", "127.0.0.1:8886", 500, nil),
}
```
Use weight_random
```go
127.0.0.1:8886
127.0.0.1:8886
127.0.0.1:8882
127.0.0.1:8885
127.0.0.1:8885
127.0.0.1:8885
127.0.0.1:8886
127.0.0.1:8886
127.0.0.1:8886
127.0.0.1:8885
```
Use round_robin
```go
127.0.0.1:8881
127.0.0.1:8882
127.0.0.1:8883
127.0.0.1:8884
127.0.0.1:8885
127.0.0.1:8886
127.0.0.1:8881
127.0.0.1:8882
127.0.0.1:8883
127.0.0.1:8884
```
Use weight_round_robin
```go
127.0.0.1:8886
127.0.0.1:8885
127.0.0.1:8886
127.0.0.1:8884
127.0.0.1:8886
127.0.0.1:8886
127.0.0.1:8885
127.0.0.1:8886
127.0.0.1:8883
127.0.0.1:8886
```

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #358 