### PR TITLE
fix(hz): Default json tag alignment protoc-gen-go

### DIFF
--- a/cmd/hz/internal/protobuf/tags.go
+++ b/cmd/hz/internal/protobuf/tags.go
@@ -258,7 +258,7 @@ func m2s(mt model.Tag) (ret [2]string) {
 
 func reflectJsonTag(f protoreflect.FieldDescriptor) (ret model.Tag) {
 	ret.Key = "json"
-	ret.Value = checkSnakeName(f.JSONName())
+	ret.Value = checkSnakeName(f.Name())
 	if v := checkFirstOption(api.E_Body, f.Options()); v != nil {
 		ret.Value += ",string"
 	}


### PR DESCRIPTION
![a9b8e1b4-5fb5-4d3e-b26a-e7ecc9ea96a9](https://user-images.githubusercontent.com/10583423/201367542-7e9b936c-b413-426d-a9f5-915255bbecdf.jpeg)

json name should be snake like form and query

**What type of PR is this?**
fix

**Check the PR title.**
 
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.

(Optional) Translate the PR title into Chinese.
修复 json 默认不是下划线的问题

**(Optional) More detail description for this PR(en: English/zh: Chinese).**


**Which issue(s) this PR fixes:**