### PR TITLE
feat: add RequestHeader.SetNoDefaultContentType

### DIFF
--- a/pkg/protocol/header_test.go
+++ b/pkg/protocol/header_test.go
@@ -44,6 +44,7 @@ package protocol
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -517,4 +518,14 @@ func TestRequestHeaderDelAllCookies(t *testing.T) {
 	if len(hv) > 0 {
 		t.Fatalf("non-zero value: %q", hv)
 	}
+}
+
+func TestRequestHeaderSetNoDefaultContentType(t *testing.T) {
+	var h RequestHeader
+	h.SetMethod(http.MethodPost)
+	b := h.AppendBytes(nil)
+	assert.DeepEqual(t, b, []byte("POST / HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\n"))
+	h.SetNoDefaultContentType(true)
+	b = h.AppendBytes(nil)
+	assert.DeepEqual(t, b, []byte("POST / HTTP/1.1\r\n\r\n"))
 }


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: When sending a HTTP request, hertz will always send a Content-Type header, if the value was not specified by the user, it will default to application/x-www-form-urlencoded. This could cause undesirable effects on the server-side. This PR adds the SetNoDefaultContentType method to RequestHeader which when set to true, will omit the Content-Type header entirely if no Content-Type was specified.
zh(optional):

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
close #360 
https://github.com/cloudwego/hertz/issues/359