### PR TITLE
fix: trace changed the root context by mistake

### DIFF
--- a/pkg/app/server/hertz_test.go
+++ b/pkg/app/server/hertz_test.go
@@ -736,3 +736,30 @@ func TestServiceRegistryNoInitInfo(t *testing.T) {
 	assert.Assert(t, atomic.LoadInt32(&rCount) == 1)
 	assert.Assert(t, atomic.LoadInt32(&drCount) == 1)
 }
+
+type testTracer struct{}
+
+func (t testTracer) Start(ctx context.Context, c *app.RequestContext) context.Context {
+	value := 0
+	if v := ctx.Value("testKey"); v != nil {
+		value = v.(int)
+		value++
+	}
+	return context.WithValue(ctx, "testKey", value)
+}
+
+func (t testTracer) Finish(ctx context.Context, c *app.RequestContext) {}
+
+func TestReuseCtx(t *testing.T) {
+	h := New(WithTracer(testTracer{}), WithHostPorts(":9228"))
+	h.GET("/ping", func(ctx context.Context, c *app.RequestContext) {
+		assert.DeepEqual(t, 0, ctx.Value("testKey").(int))
+	})
+
+	go h.Spin()
+	time.Sleep(time.Second)
+	for i := 0; i < 1000; i++ {
+		_, _, err := c.Get(context.Background(), nil, "http://127.0.0.1:9228/ping")
+		assert.Nil(t, err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
trace 错误的修改了根 context

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: standard context use the same one in http1.Serve. In the case of long connections, the context will become larger and larger, and in extreme scenarios, the search overhead will be high.
zh: http1 Serve 方法中使用同一个 context。在长连接情况下，会导致 context 越来越大，在极端场景下导致查找开销大。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
