### PR TITLE
ci: automatically skip when there is a label except `invalid issue`

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   triage:
+    if: contains(github.event.issue.labels.*.name, 'invalid issue') || join(github.event.issue.labels) == ''
     runs-on: ubuntu-latest
     name: Label issues
     steps:


### PR DESCRIPTION
#### What type of PR is this?

ci
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.

当 issue 已经设置好标签时，ci 自动豁免，除了 `invalid issue` 标签。

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: 
When we don't want to use the ci that automatically increases the label in some cases, we can judge by whether there is a label. When there is a label that is not the `invalid issue`, ci will be skipped.

zh(optional): 
在某些情况下我们不想使用自动增加标签的 ci 时，可以通过是否有标签来判断。当有标签不是 `invalid issue` 时，将跳过 ci。

Reference: https://stackoverflow.com/questions/63637826/how-to-check-if-an-issue-has-no-labels-in-a-github-workflow

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
