### PR TITLE
test: fix netpoll ut in windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,18 +22,18 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Lint
-        run: |
-          go vet -stdmethods=false $(go list ./...)
-          go install mvdan.cc/gofumpt@v0.2.0
-          test -z "$(gofumpt -l -extra .)"
+      - name: Golangci Lint
+        # https://golangci-lint.run/
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
       - name: Unit Test
         run: go test -race -covermode=atomic -coverprofile=coverage.txt ./...
 
       - name: Codecov
         run: bash <(curl -s https://codecov.io/bash)
 
-  lint-and-ut-windows:
+  ut-windows:
     strategy:
       matrix:
         version: [ 1.18, 1.19 ]
@@ -52,13 +52,5 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - name: Lint
-        run: |
-          go vet -stdmethods=false $(go list ./...)
-          go install mvdan.cc/gofumpt@v0.2.0
-          test -z "$(gofumpt -l -extra .)"
       - name: Unit Test
-        run: go test -race -covermode=atomic -coverprofile=coverage.txt ./...
-#
-#      - name: Codecov
-#        run: bash <(curl -s https://codecov.io/bash)
+        run: go test -race -covermode=atomic  ./...

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,35 @@
+# Options for analysis running.
+run:
+  # include `vendor` `third_party` `testdata` `examples` `Godeps` `builtin`
+  skip-dirs-use-default: true
+# output configuration options
+
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 30m
+
+output:
+  # Format: colored-line-number|line-number|json|tab|checkstyle|code-climate|junit-xml|github-actions
+  format: colored-line-number
+# All available settings of specific linters.
+# Refer to https://golangci-lint.run/usage/linters
+linters-settings:
+  govet:
+    # Disable analyzers by name.
+    # Run `go tool vet help` to see all analyzers.
+    disable:
+      - stdmethods
+linters:
+  enable:
+    - gofumpt
+    - goimports
+    - gofmt
+    - govet
+  disable:
+    - errcheck
+    - typecheck
+    - deadcode
+    - varcheck
+    - staticcheck
+issues:
+  exclude-use-default: true

--- a/cmd/hz/protobuf/api/api.pb.go
+++ b/cmd/hz/protobuf/api/api.pb.go
@@ -7,10 +7,11 @@
 package api
 
 import (
+	reflect "reflect"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	descriptorpb "google.golang.org/protobuf/types/descriptorpb"
-	reflect "reflect"
 )
 
 const (

--- a/licenses/LICENSE-fsnotify
+++ b/licenses/LICENSE-fsnotify
@@ -1,0 +1,25 @@
+Copyright © 2012 The Go Authors. All rights reserved.
+Copyright © fsnotify Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+* Neither the name of Google Inc. nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pkg/app/client/client_test.go
+++ b/pkg/app/client/client_test.go
@@ -1898,7 +1898,10 @@ func (m *mockDialer) DialConnection(network, address string, timeout time.Durati
 func TestClientRetry(t *testing.T) {
 	t.Parallel()
 	client, err := NewClient(
-		WithDialTimeout(2*time.Second),
+		// Default dial function performs different in different os. So unit the performance of dial function.
+		WithDialFunc(func(addr string) (network.Conn, error) {
+			return nil, fmt.Errorf("dial tcp %s: i/o timeout", addr)
+		}),
 		WithRetryConfig(
 			retry.WithMaxAttemptTimes(3),
 			retry.WithInitDelay(100*time.Millisecond),
@@ -1927,7 +1930,9 @@ func TestClientRetry(t *testing.T) {
 	}
 
 	client2, err := NewClient(
-		WithDialTimeout(2*time.Second),
+		WithDialFunc(func(addr string) (network.Conn, error) {
+			return nil, fmt.Errorf("dial tcp %s: i/o timeout", addr)
+		}),
 		WithRetryConfig(
 			retry.WithMaxAttemptTimes(2),
 			retry.WithInitDelay(500*time.Millisecond),
@@ -1956,7 +1961,9 @@ func TestClientRetry(t *testing.T) {
 	}
 
 	client3, err := NewClient(
-		WithDialTimeout(2*time.Second),
+		WithDialFunc(func(addr string) (network.Conn, error) {
+			return nil, fmt.Errorf("dial tcp %s: i/o timeout", addr)
+		}),
 		WithRetryConfig(
 			retry.WithMaxAttemptTimes(2),
 			retry.WithInitDelay(100*time.Millisecond),
@@ -1986,7 +1993,9 @@ func TestClientRetry(t *testing.T) {
 	}
 
 	client4, err := NewClient(
-		WithDialTimeout(2*time.Second),
+		WithDialFunc(func(addr string) (network.Conn, error) {
+			return nil, fmt.Errorf("dial tcp %s: i/o timeout", addr)
+		}),
 		WithRetryConfig(
 			retry.WithMaxAttemptTimes(2),
 			retry.WithInitDelay(1*time.Second),

--- a/pkg/app/client/client_unix_test.go
+++ b/pkg/app/client/client_unix_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package client
+
+import (
+	"crypto/tls"
+	"math/rand"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/network"
+	"github.com/cloudwego/hertz/pkg/network/netpoll"
+	"github.com/cloudwego/hertz/pkg/network/standard"
+)
+
+func newMockDialerWithCustomFunc(network, address string, timeout time.Duration, f func(network, address string, timeout time.Duration, tlsConfig *tls.Config)) network.Dialer {
+	dialer := standard.NewDialer()
+	if rand.Intn(2) == 0 {
+		dialer = netpoll.NewDialer()
+	}
+	return &mockDialer{
+		Dialer:           dialer,
+		customDialerFunc: f,
+		network:          network,
+		address:          address,
+		timeout:          timeout,
+	}
+}

--- a/pkg/app/client/client_windows_test.go
+++ b/pkg/app/client/client_windows_test.go
@@ -1,0 +1,38 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build windows
+// +build windows
+
+package client
+
+import (
+	"crypto/tls"
+	"time"
+
+	"github.com/cloudwego/hertz/pkg/network"
+	"github.com/cloudwego/hertz/pkg/network/standard"
+)
+
+func newMockDialerWithCustomFunc(network, address string, timeout time.Duration, f func(network, address string, timeout time.Duration, tlsConfig *tls.Config)) network.Dialer {
+	dialer := standard.NewDialer()
+	return &mockDialer{
+		Dialer:           dialer,
+		customDialerFunc: f,
+		network:          network,
+		address:          address,
+		timeout:          timeout,
+	}
+}

--- a/pkg/app/client/option.go
+++ b/pkg/app/client/option.go
@@ -180,8 +180,7 @@ type customDialer struct {
 	dialFunc network.DialFunc
 }
 
-func (m *customDialer) DialConnection(network, address string, timeout time.Duration,
-	tlsConfig *tls.Config) (conn network.Conn, err error) {
+func (m *customDialer) DialConnection(network, address string, timeout time.Duration, tlsConfig *tls.Config) (conn network.Conn, err error) {
 	if m.dialFunc != nil {
 		return m.dialFunc(address)
 	}

--- a/pkg/app/server/hertz_unix_test.go
+++ b/pkg/app/server/hertz_unix_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package server
+
+import (
+	"context"
+	"net"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cloudwego/hertz/pkg/app"
+	c "github.com/cloudwego/hertz/pkg/app/client"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/common/utils"
+	"github.com/cloudwego/hertz/pkg/network/standard"
+	"github.com/cloudwego/hertz/pkg/protocol/consts"
+)
+
+func TestReusePorts(t *testing.T) {
+	cfg := &net.ListenConfig{Control: func(network, address string, c syscall.RawConn) error {
+		return c.Control(func(fd uintptr) {
+			syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+			syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		})
+	}}
+	ha := New(WithHostPorts("localhost:10093"), WithListenConfig(cfg), WithTransport(standard.NewTransporter))
+	hb := New(WithHostPorts("localhost:10093"), WithListenConfig(cfg), WithTransport(standard.NewTransporter))
+	hc := New(WithHostPorts("localhost:10093"), WithListenConfig(cfg))
+	hd := New(WithHostPorts("localhost:10093"), WithListenConfig(cfg))
+	ha.GET("/ping", func(c context.Context, ctx *app.RequestContext) {
+		ctx.JSON(consts.StatusOK, utils.H{"ping": "pong"})
+	})
+	hc.GET("/ping", func(c context.Context, ctx *app.RequestContext) {
+		ctx.JSON(consts.StatusOK, utils.H{"ping": "pong"})
+	})
+	hd.GET("/ping", func(c context.Context, ctx *app.RequestContext) {
+		ctx.JSON(consts.StatusOK, utils.H{"ping": "pong"})
+	})
+	hb.GET("/ping", func(c context.Context, ctx *app.RequestContext) {
+		ctx.JSON(consts.StatusOK, utils.H{"ping": "pong"})
+	})
+	go ha.Run()
+	go hb.Run()
+	go hc.Run()
+	go hd.Run()
+	time.Sleep(time.Second)
+
+	client, _ := c.NewClient()
+	for i := 0; i < 1000; i++ {
+		statusCode, body, err := client.Get(context.Background(), nil, "http://localhost:10093/ping")
+		assert.Nil(t, err)
+		assert.DeepEqual(t, consts.StatusOK, statusCode)
+		assert.DeepEqual(t, "{\"ping\":\"pong\"}", string(body))
+	}
+}

--- a/pkg/app/server/render/html.go
+++ b/pkg/app/server/render/html.go
@@ -113,7 +113,6 @@ type HTMLDebug struct {
 	sync.Once
 	Template        *template.Template
 	RefreshInterval time.Duration
-	updateTimeStamp time.Time
 
 	Files   []string
 	FuncMap template.FuncMap
@@ -161,14 +160,10 @@ func (h *HTMLDebug) startChecker() {
 	if h.RefreshInterval > 0 {
 		go func() {
 			hlog.SystemLogger().Debugf("[HTMLDebug] HTML template reloader started with interval %v", h.RefreshInterval)
-			for {
-				n := time.Now()
-				if n.UTC().Sub(h.updateTimeStamp.UTC()) > h.RefreshInterval {
-					hlog.SystemLogger().Debugf("[HTMLDebug] triggering HTML template reloader")
-					h.reloadCh <- struct{}{}
-					hlog.SystemLogger().Debugf("[HTMLDebug] HTML template has been reloaded, next reload in %v", h.RefreshInterval)
-					h.updateTimeStamp = time.Now()
-				}
+			for range time.Tick(h.RefreshInterval) {
+				hlog.SystemLogger().Debugf("[HTMLDebug] triggering HTML template reloader")
+				h.reloadCh <- struct{}{}
+				hlog.SystemLogger().Debugf("[HTMLDebug] HTML template has been reloaded, next reload in %v", h.RefreshInterval)
 			}
 		}()
 		return

--- a/pkg/app/server/render/html_test.go
+++ b/pkg/app/server/render/html_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestHTMLDebug_StartChecker_timer(t *testing.T) {
-	render := &HTMLDebug{RefreshInterval: 2 * time.Second}
+	render := &HTMLDebug{RefreshInterval: time.Second}
 	select {
 	case <-render.reloadCh:
 		t.Fatalf("should not be triggered")
@@ -31,17 +31,9 @@ func TestHTMLDebug_StartChecker_timer(t *testing.T) {
 	}
 	render.startChecker()
 	select {
-	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("should be triggered immediately")
+	case <-time.After(render.RefreshInterval + 100*time.Millisecond):
+		t.Fatalf("should be triggered in 1 second")
 	case <-render.reloadCh:
-
-	}
-	select {
-	// some ci servers have poor computing power, so we add some extra time here.
-	case <-time.After(2*time.Second + 50*time.Millisecond):
-		t.Fatalf("should be triggered before 2 seconds")
-	case <-render.reloadCh:
-		t.Logf("paas")
 	}
 }
 
@@ -59,7 +51,7 @@ func TestHTMLDebug_StartChecker_fs_watcher(t *testing.T) {
 	}
 	render.startChecker()
 	f.Write([]byte("hello"))
-
+	f.Sync()
 	select {
 	case <-time.After(50 * time.Millisecond):
 		t.Fatalf("should be triggered immediately")

--- a/pkg/network/netpoll/connection.go
+++ b/pkg/network/netpoll/connection.go
@@ -1,21 +1,17 @@
-//go:build !windows
-// +build !windows
-
-/*
- * Copyright 2022 CloudWeGo Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 
 package netpoll
 
@@ -29,7 +25,6 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/hlog"
 	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/netpoll"
-	"golang.org/x/sys/unix"
 )
 
 type Conn struct {
@@ -37,7 +32,7 @@ type Conn struct {
 }
 
 func (c *Conn) ToHertzError(err error) error {
-	if errors.Is(err, netpoll.ErrConnClosed) || errors.Is(err, unix.EPIPE) {
+	if errors.Is(err, netpoll.ErrConnClosed) || errors.Is(err, syscall.EPIPE) {
 		return errs.ErrConnectionClosed
 	}
 	return err

--- a/pkg/network/netpoll/connection_test.go
+++ b/pkg/network/netpoll/connection_test.go
@@ -1,18 +1,20 @@
-/*
- * Copyright 2022 CloudWeGo Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2022 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+//go:build !windows
+// +build !windows
 
 package netpoll
 

--- a/pkg/network/netpoll/dial.go
+++ b/pkg/network/netpoll/dial.go
@@ -13,9 +13,6 @@
 // limitations under the License.
 //
 
-//go:build !windows
-// +build !windows
-
 package netpoll
 
 import (

--- a/pkg/network/netpoll/transport.go
+++ b/pkg/network/netpoll/transport.go
@@ -1,21 +1,20 @@
+// Copyright 2022 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 //go:build !windows
 // +build !windows
-
-/*
- * Copyright 2022 CloudWeGo Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 package netpoll
 

--- a/pkg/network/utils_test.go
+++ b/pkg/network/utils_test.go
@@ -18,10 +18,15 @@ package network
 
 import (
 	"os"
+	"runtime"
 	"testing"
 )
 
 func TestUnlinkUdsFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.SkipNow()
+	}
+
 	tmp := "tmpFile"
 	var err error
 

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -59,7 +59,6 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/test/assert"
 	"github.com/cloudwego/hertz/pkg/common/test/mock"
 	"github.com/cloudwego/hertz/pkg/network"
-	"github.com/cloudwego/hertz/pkg/network/netpoll"
 	"github.com/cloudwego/hertz/pkg/network/standard"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
@@ -75,16 +74,16 @@ func TestNew_Engine(t *testing.T) {
 }
 
 func TestNew_Engine_WithTransporter(t *testing.T) {
-	defaultTransporter = netpoll.NewTransporter
+	defaultTransporter = newMockTransporter
 	opt := config.NewOptions([]config.Option{})
 	router := NewEngine(opt)
-	assert.DeepEqual(t, "netpoll", router.GetTransporterName())
+	assert.DeepEqual(t, "route", router.GetTransporterName())
 
-	defaultTransporter = netpoll.NewTransporter
+	defaultTransporter = newMockTransporter
 	opt.TransporterNewer = standard.NewTransporter
 	router = NewEngine(opt)
 	assert.DeepEqual(t, "standard", router.GetTransporterName())
-	assert.DeepEqual(t, "netpoll", GetTransporterName())
+	assert.DeepEqual(t, "route", GetTransporterName())
 }
 
 func TestGetTransporterName(t *testing.T) {
@@ -419,16 +418,15 @@ func TestRenderHtml(t *testing.T) {
 }
 
 func TestTransporterName(t *testing.T) {
-	SetTransporter(netpoll.NewTransporter)
-	assert.DeepEqual(t, "netpoll", GetTransporterName())
-
 	SetTransporter(standard.NewTransporter)
 	assert.DeepEqual(t, "standard", GetTransporterName())
 
-	SetTransporter(func(options *config.Options) network.Transporter {
-		return &mockTransporter{}
-	})
+	SetTransporter(newMockTransporter)
 	assert.DeepEqual(t, "route", GetTransporterName())
+}
+
+func newMockTransporter(options *config.Options) network.Transporter {
+	return &mockTransporter{}
 }
 
 type mockTransporter struct{}

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -285,8 +285,8 @@ func TestIdleTimeout03(t *testing.T) {
 			t.Errorf("err should be ErrShortConnection, but got %s", err)
 		}
 		return
-	case <-time.Tick(120 * time.Millisecond):
-		t.Errorf("timeout! should have been finished in 120ms...")
+	case <-time.Tick(200 * time.Millisecond):
+		t.Errorf("timeout! should have been finished in 200ms...")
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
test

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复 windows 环境允许netpoll相关单测报错的问题

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
1. Specify newMockDialerFunc to use the standard library in the windows environment, and use netpoll in the unix environment
2. TestReusePorts, TestHertz_Spin, TestUnlinkUdsFile only run in unix environment
3. In TestClientRetry, unify the behavior of DialFunc in windows and unix. When dialing an address that does not exist, the standard library under windows will wait until dialtimeout times out; netpoll under unix will return directly.
4. Increase the waiting time in TestIdleTimeout03
5. Call `f.Sync` after `f.Write` in TestHTMLDebug_StartChecker_fs_watcher to trigger file change monitoring
6. Optimize the trigger logic of html debugRender after setting refreshInterval
7. Change gofumpt lint to go lint
8. Fix the panic caused by TestOnPrePare closing the connection and reclaiming the buffer
9. The uri-related unit test is an implementation bug, which will be fixed in the next PR

zh(optional):
1. 指定 newMockDialerFunc 在 windows 环境下使用标准库，在 unix 环境下使用 netpoll
2. TestReusePorts、TestHertz_Spin、TestUnlinkUdsFile 只在 unix 环境下运行
3. 在 TestClientRetry 中，统一 DialFunc 在 windows 和 unix 的行为。在 dial 一个不存在的地址时，windows 下标准库会等待直到 dialtimeout 超时；unix 下 netpoll 会直接返回。
4. TestIdleTimeout03 中增加等待时间
5. TestHTMLDebug_StartChecker_fs_watcher 中在 `f.Write` 后调用 `f.Sync` 使其触发文件变动监听
6. 优化 html debugRender 在设置 refreshInterval 后的触发逻辑
7. 将 gofumpt lint 改为 go lint
8. 修复 TestOnPrePare 关闭连接回收 buffer 导致的 panic
9. uri 相关单测没过是实现 bug，在接下来 pr 中修复
#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
