### PR TITLE
fix: `CopyTo` doesn't copy bodyraw deeply

### DIFF
--- a/pkg/protocol/request.go
+++ b/pkg/protocol/request.go
@@ -347,7 +347,7 @@ func (req *Request) SwapBody(body []byte) []byte {
 func (req *Request) CopyTo(dst *Request) {
 	req.CopyToSkipBody(dst)
 	if req.bodyRaw != nil {
-		dst.bodyRaw = req.bodyRaw
+		dst.bodyRaw = append(dst.bodyRaw[:0], req.bodyRaw...)
 		if dst.body != nil {
 			dst.body.Reset()
 		}

--- a/pkg/protocol/request_test.go
+++ b/pkg/protocol/request_test.go
@@ -748,3 +748,18 @@ func testBodyWriteTo(t *testing.T, bw bodyWriterTo, expectedS string, isRetained
 		}
 	}
 }
+
+func TestReqSafeCopy(t *testing.T) {
+	req := AcquireRequest()
+	req.bodyRaw = make([]byte, 1)
+	reqs := make([]*Request, 10)
+	for i := 0; i < 10; i++ {
+		req.bodyRaw[0] = byte(i)
+		tmpReq := AcquireRequest()
+		req.CopyTo(tmpReq)
+		reqs[i] = tmpReq
+	}
+	for i := 0; i < 10; i++ {
+		assert.DeepEqual(t, []byte{byte(i)}, reqs[i].Body())
+	}
+}

--- a/pkg/protocol/response.go
+++ b/pkg/protocol/response.go
@@ -240,7 +240,7 @@ func (resp *Response) BodyWriteTo(w io.Writer) error {
 func (resp *Response) CopyTo(dst *Response) {
 	resp.CopyToSkipBody(dst)
 	if resp.bodyRaw != nil {
-		dst.bodyRaw = resp.bodyRaw
+		dst.bodyRaw = append(dst.bodyRaw[:0], resp.bodyRaw...)
 		if dst.body != nil {
 			dst.body.Reset()
 		}

--- a/pkg/protocol/response_test.go
+++ b/pkg/protocol/response_test.go
@@ -257,3 +257,18 @@ func TestSetBodyStreamNoReset(t *testing.T) {
 	resp.SetBodyStream(bsC, 1)
 	assert.DeepEqual(t, bsA.String(), "")
 }
+
+func TestRespSafeCopy(t *testing.T) {
+	resp := AcquireResponse()
+	resp.bodyRaw = make([]byte, 1)
+	resps := make([]*Response, 10)
+	for i := 0; i < 10; i++ {
+		resp.bodyRaw[0] = byte(i)
+		tmpResq := AcquireResponse()
+		resp.CopyTo(tmpResq)
+		resps[i] = tmpResq
+	}
+	for i := 0; i < 10; i++ {
+		assert.DeepEqual(t, []byte{byte(i)}, resps[i].Body())
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
`CopyTo`  没有深拷贝 `bodyRaw`

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: `CopyTo` doesn't copy `bodyraw` deeply
zh(optional): `CopyTo`  没有深拷贝 `bodyRaw`

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
