### PR TITLE
fix: uri normalize in windows

### DIFF
--- a/pkg/app/server/hertz_test.go
+++ b/pkg/app/server/hertz_test.go
@@ -157,7 +157,9 @@ func TestLoadHTMLGlob(t *testing.T) {
 	assert.DeepEqual(t, consts.StatusOK, resp.StatusCode)
 	b := make([]byte, 100)
 	n, _ := resp.Body.Read(b)
-	assert.DeepEqual(t, "<html>\n<h1>\n    Main website\n</h1>\n</html>", string(b[0:n]))
+	const expected = `<html><h1>Main website</h1></html>`
+
+	assert.DeepEqual(t, expected, string(b[0:n]))
 }
 
 func TestLoadHTMLFiles(t *testing.T) {

--- a/pkg/common/testdata/template/index.tmpl
+++ b/pkg/common/testdata/template/index.tmpl
@@ -1,5 +1,1 @@
-<html>
-<h1>
-    {[{ .title }]}
-</h1>
-</html>
+<html><h1>{[{ .title }]}</h1></html>

--- a/pkg/protocol/uri_windows.go
+++ b/pkg/protocol/uri_windows.go
@@ -46,7 +46,8 @@ package protocol
 
 func addLeadingSlash(dst, src []byte) []byte {
 	// zero length and "C:/" case
-	if len(src) == 0 || (len(src) > 2 && src[1] != ':') {
+	isDisk := len(src) > 2 && src[1] == ':'
+	if len(src) == 0 || (!isDisk && src[0] != '/') {
 		dst = append(dst, '/')
 	}
 

--- a/pkg/protocol/uri_windows_test.go
+++ b/pkg/protocol/uri_windows_test.go
@@ -1,0 +1,28 @@
+// Copyright 2023 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protocol
+
+import "testing"
+
+func TestURIPathNormalizeIssue86(t *testing.T) {
+	t.Parallel()
+
+	var u URI
+
+	testURIPathNormalize(t, &u, `a`, `/a`)
+	testURIPathNormalize(t, &u, "/../../../../../foo", "/foo")
+	testURIPathNormalize(t, &u, "/..\\..\\..\\..\\..\\", "/")
+	testURIPathNormalize(t, &u, "/..%5c..%5cfoo", "/foo")
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复 uri 在 windows 下的统一化

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: fix uri normalize in windows which is the #536 left problem. Before fixed, `a` won't be normalized to `/a` in windows scenario
zh(optional): 修复 uri 在 windows 下的统一化，#536 遗留问题。未修复之前，`a` 不会被归一化为 `/a`

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
