### PR TITLE
fix: skip rest chunked body correctly

### DIFF
--- a/pkg/protocol/http1/ext/stream.go
+++ b/pkg/protocol/http1/ext/stream.go
@@ -251,7 +251,7 @@ func (rs *bodyStream) skipRest() error {
 
 			if chunkSize == 0 {
 				rs.chunkEOF = true
-				return utils.SkipCRLF(rs.reader)
+				return SkipTrailer(rs.reader)
 			}
 
 			err = rs.reader.Skip(chunkSize)

--- a/pkg/protocol/http1/ext/stream_test.go
+++ b/pkg/protocol/http1/ext/stream_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ext
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/bytebufferpool"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/common/test/mock"
+)
+
+func createChunkedBody(body, rest []byte) []byte {
+	var b []byte
+	chunkSize := 1
+	for len(body) > 0 {
+		if chunkSize > len(body) {
+			chunkSize = len(body)
+		}
+		b = append(b, []byte(fmt.Sprintf("%x\r\n", chunkSize))...)
+		b = append(b, body[:chunkSize]...)
+		b = append(b, []byte("\r\n")...)
+		body = body[chunkSize:]
+		chunkSize++
+	}
+	b = append(b, []byte("0\r\n\r\n")...)
+	return append(b, rest...)
+}
+
+func testChunkedSkipRest(t *testing.T, data, rest string) {
+	var pool bytebufferpool.Pool
+	reader := mock.NewZeroCopyReader(data)
+
+	bs := AcquireBodyStream(pool.Get(), reader, -1)
+	err := bs.(*bodyStream).skipRest()
+	assert.Nil(t, err)
+
+	rest_data, err := io.ReadAll(reader)
+	assert.Nil(t, err)
+	assert.DeepEqual(t, rest, string(rest_data))
+}
+
+func testChunkedSkipRestWithBodySize(t *testing.T, bodySize int) {
+	body := mock.CreateFixedBody(bodySize)
+	rest := mock.CreateFixedBody(bodySize)
+	data := createChunkedBody(body, rest)
+
+	testChunkedSkipRest(t, string(data), string(rest))
+}
+
+func TestChunkedSkipRest(t *testing.T) {
+	t.Parallel()
+
+	testChunkedSkipRest(t, "0\r\n\r\n", "")
+	testChunkedSkipRest(t, "0\r\n\r\nHTTP/1.1 / POST", "HTTP/1.1 / POST")
+
+	testChunkedSkipRestWithBodySize(t, 5)
+
+	// medium-size body
+	testChunkedSkipRestWithBodySize(t, 43488)
+
+	// big body
+	testChunkedSkipRestWithBodySize(t, 3*1024*1024)
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
正确的忽略剩余的chunked body

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: When the request's `Transfor-Encoding` is chunked, the server has the WithStreamBody option and the handler returns without processing body, hertz will treat the unprocessed body as a new http request.

zh(optional): 当 request 的 `Transfor-Encoding` 为 chunked，且 server 打开了 `WithStreamBody` 选项，如果 handler 没有处理 body 而直接返回，hertz 会将没有处理的 body 作为新的 http 请求。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
