### PR TITLE
fix(hz): bad separator

### DIFF
--- a/cmd/hz/app/app.go
+++ b/cmd/hz/app/app.go
@@ -157,8 +157,8 @@ func Init() *cli.App {
 	unsetOmitemptyFlag := cli.BoolFlag{Name: "unset_omitempty", Usage: "Remove 'omitempty' tag for generated struct.", Destination: &globalArgs.UnsetOmitempty}
 	protoCamelJSONTag := cli.BoolFlag{Name: "pb_camel_json_tag", Usage: "Convert Name style for json tag to camel(Only works protobuf).", Destination: &globalArgs.ProtobufCamelJSONTag}
 	snakeNameFlag := cli.BoolFlag{Name: "snake_tag", Usage: "Use snake_case style naming for tags. (Only works for 'form', 'query', 'json')", Destination: &globalArgs.SnakeName}
-	customLayout := cli.StringFlag{Name: "customize_layout", Usage: "Specify the layout template. ({{Template Profile}}:{{Rendering Data}})", Destination: &globalArgs.CustomizeLayout}
-	customPackage := cli.StringFlag{Name: "customize_package", Usage: "Specify the package template. ({{Template Profile}}:)", Destination: &globalArgs.CustomizePackage}
+	customLayout := cli.StringFlag{Name: "customize_layout", Usage: "Specify the layout template. ({{Template Profile}}|{{Rendering Data}})", Destination: &globalArgs.CustomizeLayout}
+	customPackage := cli.StringFlag{Name: "customize_package", Usage: "Specify the package template. ({{Template Profile}}|)", Destination: &globalArgs.CustomizePackage}
 	handlerByMethod := cli.BoolFlag{Name: "handler_by_method", Usage: "Generate a separate handler file for each method.", Destination: &globalArgs.HandlerByMethod}
 
 	// app
@@ -318,9 +318,9 @@ func GenerateLayout(args *config.Argument) error {
 		}
 	} else {
 		// generate by customized layout
-		sp := strings.Split(args.CustomizeLayout, ":")
+		sp := strings.Split(args.CustomizeLayout, "|")
 		if len(sp) != 2 || sp[0] == "" {
-			return errors.New("custom_layout must be like: {{layout_config_path}}:{{template_data_config_path}}")
+			return errors.New("custom_layout must be like: {{layout_config_path}}|{{template_data_config_path}}")
 		}
 		configPath, dataPath := sp[0], sp[1]
 		logs.Infof("get customized layout info, layout_config_path: %s, template_data_path: %s", configPath, dataPath)

--- a/cmd/hz/protobuf/plugin.go
+++ b/cmd/hz/protobuf/plugin.go
@@ -560,7 +560,7 @@ func (plugin *Plugin) genHttpPackage(ast *descriptorpb.FileDescriptorProto, deps
 		return nil, err
 	}
 
-	cf, _ := util.GetColonPair(args.CustomizePackage)
+	cf, _ := util.GetVerticalBarPair(args.CustomizePackage)
 	pkg, err := args.GetGoPackage()
 	if err != nil {
 		return nil, err

--- a/cmd/hz/thrift/plugin.go
+++ b/cmd/hz/thrift/plugin.go
@@ -97,7 +97,7 @@ func (plugin *Plugin) Run() int {
 		return meta.PluginError
 	}
 
-	cf, _ := util.GetColonPair(args.CustomizePackage)
+	cf, _ := util.GetVerticalBarPair(args.CustomizePackage)
 	pkg, err := args.GetGoPackage()
 	if err != nil {
 		logs.Errorf("get go package failed: %s", err.Error())

--- a/cmd/hz/thrift/plugin_test.go
+++ b/cmd/hz/thrift/plugin_test.go
@@ -54,7 +54,7 @@ func TestRun(t *testing.T) {
 	}
 
 	args := plu.args
-	cf, _ := util.GetColonPair(args.CustomizePackage)
+	cf, _ := util.GetVerticalBarPair(args.CustomizePackage)
 	pkg, err := args.GetGoPackage()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/hz/util/data.go
+++ b/cmd/hz/util/data.go
@@ -213,8 +213,8 @@ func GetFirstKV(m map[string][]string) (string, []string) {
 	return "", nil
 }
 
-func GetColonPair(str string) (string, string) {
-	ps := strings.Split(str, ":")
+func GetVerticalBarPair(str string) (string, string) {
+	ps := strings.Split(str, "|")
 	if len(ps) != 2 {
 		return "", ""
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修改 hz cmd 的分隔符

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: Change the separator of the `customize_package` and `customize_layout` options in hz cmd from `:` to `|` to avoid conflicts with `C:` in the windows path
zh(optional): 将 hz cmd 的 `customize_package`和`customize_layout`两个选项的分隔符从 `:` 变为 `|` 以避免与 windows 路径中的 `C:` 冲突

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
