### PR TITLE
feat(http1): support flush chunk in handler

### DIFF
--- a/examples/standard/main.go
+++ b/examples/standard/main.go
@@ -19,14 +19,11 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/cloudwego/hertz/pkg/app"
 	"github.com/cloudwego/hertz/pkg/app/server"
 	"github.com/cloudwego/hertz/pkg/common/utils"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
-	"github.com/cloudwego/hertz/pkg/protocol/http1/resp"
 )
 
 type Test struct {
@@ -51,17 +48,6 @@ func main() {
 
 	h.GET("/redirect", func(c context.Context, ctx *app.RequestContext) {
 		ctx.Redirect(consts.StatusMovedPermanently, []byte("http://www.google.com/"))
-	})
-
-	h.GET("/flush/chunk", func(c context.Context, ctx *app.RequestContext) {
-		// Hijack the writer of response
-		ctx.Response.HijackWriter(resp.NewChunkedBodyWriter(&ctx.Response, ctx.GetWriter()))
-
-		for i := 0; i < 10; i++ {
-			ctx.Write([]byte(fmt.Sprintf("chunk %d: %s", i, strings.Repeat("hi~", i)))) // nolint: errcheck
-			ctx.Flush()                                                                 // nolint: errcheck
-			time.Sleep(200 * time.Millisecond)
-		}
 	})
 
 	v1 := h.Group("/v1")

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -161,6 +161,15 @@ type RequestContext struct {
 	formValueFunc FormValueFunc
 }
 
+// Flush is the shortcut for ctx.Response.GetHijackWriter().Flush().
+// Will return nil if the response writer is not hijacked.
+func (ctx *RequestContext) Flush() error {
+	if ctx.Response.GetHijackWriter() == nil {
+		return nil
+	}
+	return ctx.Response.GetHijackWriter().Flush()
+}
+
 func (ctx *RequestContext) SetClientIPFunc(f ClientIP) {
 	ctx.clientIPFunc = f
 }

--- a/pkg/app/fs.go
+++ b/pkg/app/fs.go
@@ -276,8 +276,6 @@ func (r *fsSmallFileReader) WriteTo(w io.Writer) (int64, error) {
 // Directory contents is returned if path points to directory.
 //
 // Use ServeFileUncompressed is you don't need serving compressed file contents.
-//
-// See also RequestCtx.SendFile.
 func ServeFile(ctx *RequestContext, path string) {
 	rootFSOnce.Do(func() {
 		rootFSHandler = rootFS.NewRequestHandler()
@@ -1204,8 +1202,6 @@ func stripLeadingSlashes(path []byte, stripSlashes int) []byte {
 //
 // ServeFile may be used for saving network traffic when serving files
 // with good compression ratio.
-//
-// See also RequestCtx.SendFile.
 func ServeFileUncompressed(ctx *RequestContext, path string) {
 	ctx.Request.Header.DelBytes(bytestr.StrAcceptEncoding)
 	ServeFile(ctx, path)

--- a/pkg/common/test/mock/writer.go
+++ b/pkg/common/test/mock/writer.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mock
+
+import "bytes"
+
+type ExtWriter struct {
+	tmp     []byte
+	Buf     *bytes.Buffer
+	IsFinal *bool
+}
+
+func (m *ExtWriter) Write(p []byte) (n int, err error) {
+	m.tmp = p
+	return len(p), nil
+}
+
+func (m *ExtWriter) Flush() error {
+	_, err := m.Buf.Write(m.tmp)
+	return err
+}
+
+func (m *ExtWriter) Finalize() error {
+	if !*m.IsFinal {
+		*m.IsFinal = true
+	}
+	return nil
+}
+
+func (m *ExtWriter) SetBody(body []byte) {
+	m.Buf.Reset()
+	m.tmp = body
+}

--- a/pkg/network/writer.go
+++ b/pkg/network/writer.go
@@ -103,3 +103,11 @@ func NewWriter(w io.Writer) Writer {
 		w: w,
 	}
 }
+
+type ExtWriter interface {
+	io.Writer
+	Flush() error
+
+	// Finalize will be called before the writer is released.
+	Finalize() error
+}

--- a/pkg/network/writer.go
+++ b/pkg/network/writer.go
@@ -108,6 +108,7 @@ type ExtWriter interface {
 	io.Writer
 	Flush() error
 
-	// Finalize will be called before the writer is released.
+	// Finalize will be called by framework before the writer is released.
+	// Implementations must guarantee that Finalize is safe for multiple calls.
 	Finalize() error
 }

--- a/pkg/protocol/http1/ext/common.go
+++ b/pkg/protocol/http1/ext/common.go
@@ -118,14 +118,14 @@ func WriteBodyChunked(w network.Writer, r io.Reader) error {
 				panic("BUG: io.Reader returned 0, nil")
 			}
 			if err == io.EOF {
-				if err = writeChunk(w, buf[:0]); err != nil {
+				if err = WriteChunk(w, buf[:0]); err != nil {
 					break
 				}
 				err = nil
 			}
 			break
 		}
-		if err = writeChunk(w, buf[:n]); err != nil {
+		if err = WriteChunk(w, buf[:n]); err != nil {
 			break
 		}
 	}
@@ -287,7 +287,7 @@ func round2(n int) int {
 	return 1 << x
 }
 
-func writeChunk(w network.Writer, b []byte) (err error) {
+func WriteChunk(w network.Writer, b []byte) (err error) {
 	n := len(b)
 	if err = bytesconv.WriteHexInt(w, n); err != nil {
 		return err

--- a/pkg/protocol/http1/ext/common.go
+++ b/pkg/protocol/http1/ext/common.go
@@ -118,14 +118,14 @@ func WriteBodyChunked(w network.Writer, r io.Reader) error {
 				panic("BUG: io.Reader returned 0, nil")
 			}
 			if err == io.EOF {
-				if err = WriteChunk(w, buf[:0]); err != nil {
+				if err = WriteChunk(w, buf[:0], true); err != nil {
 					break
 				}
 				err = nil
 			}
 			break
 		}
-		if err = WriteChunk(w, buf[:n]); err != nil {
+		if err = WriteChunk(w, buf[:n], true); err != nil {
 			break
 		}
 	}
@@ -287,7 +287,7 @@ func round2(n int) int {
 	return 1 << x
 }
 
-func WriteChunk(w network.Writer, b []byte) (err error) {
+func WriteChunk(w network.Writer, b []byte, withFlush bool) (err error) {
 	n := len(b)
 	if err = bytesconv.WriteHexInt(w, n); err != nil {
 		return err
@@ -303,6 +303,9 @@ func WriteChunk(w network.Writer, b []byte) (err error) {
 		w.WriteBinary(bytestr.StrCRLF) //nolint:errcheck
 	}
 
+	if !withFlush {
+		return nil
+	}
 	err = w.Flush()
 	return
 }

--- a/pkg/protocol/http1/resp/writer.go
+++ b/pkg/protocol/http1/resp/writer.go
@@ -20,6 +20,7 @@ type chunkedBodyWriter struct {
 // It will only return the length of p and a nil error if the writing is successful or 0, error otherwise.
 func (c *chunkedBodyWriter) Write(p []byte) (n int, err error) {
 	if !c.wroteHeader {
+		c.r.Header.SetContentLength(-1)
 		if err = WriteHeader(&c.r.Header, c.w); err != nil {
 			return
 		}

--- a/pkg/protocol/http1/resp/writer.go
+++ b/pkg/protocol/http1/resp/writer.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package resp
 
 import (

--- a/pkg/protocol/http1/resp/writer.go
+++ b/pkg/protocol/http1/resp/writer.go
@@ -1,0 +1,48 @@
+package resp
+
+import (
+	"github.com/cloudwego/hertz/pkg/network"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/cloudwego/hertz/pkg/protocol/http1/ext"
+)
+
+type chunkedBodyWriter struct {
+	wroteHeader bool
+	r           *protocol.Response
+	w           network.Writer
+}
+
+// Write will encode chunked p before writing
+// It will only return the length of p and a nil error if the writing is successful or 0, error otherwise.
+func (c *chunkedBodyWriter) Write(p []byte) (n int, err error) {
+	if !c.wroteHeader {
+		if err = WriteHeader(&c.r.Header, c.w); err != nil {
+			return
+		}
+		c.wroteHeader = true
+	}
+	if err = ext.WriteChunk(c.w, p); err != nil {
+		return
+	}
+	return len(p), nil
+}
+
+func (c *chunkedBodyWriter) Flush() error {
+	return c.w.Flush()
+}
+
+// Finalize will write the ending chunk and flush the writer
+func (c *chunkedBodyWriter) Finalize() error {
+	err := ext.WriteChunk(c.w, nil)
+	if err != nil {
+		return err
+	}
+	return ext.WriteTrailer(c.r.Header.Trailer(), c.w)
+}
+
+func NewChunkedBodyWriter(r *protocol.Response, w network.Writer) network.ExtWriter {
+	return &chunkedBodyWriter{
+		r: r,
+		w: w,
+	}
+}

--- a/pkg/protocol/http1/resp/writer_test.go
+++ b/pkg/protocol/http1/resp/writer_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudwego/hertz/internal/bytestr"
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/common/test/mock"
+	"github.com/cloudwego/hertz/pkg/protocol"
+)
+
+func TestNewChunkedBodyWriter(t *testing.T) {
+	response := protocol.AcquireResponse()
+	mockConn := mock.NewConn("")
+	w := NewChunkedBodyWriter(response, mockConn)
+	w.Write([]byte("hello"))
+	w.Flush()
+	out, _ := mockConn.WriterRecorder().ReadBinary(mockConn.WriterRecorder().WroteLen())
+	assert.True(t, strings.Contains(string(out), "Transfer-Encoding: chunked"))
+	assert.True(t, strings.Contains(string(out), "5"+string(bytestr.StrCRLF)+"hello"))
+	assert.False(t, strings.Contains(string(out), "0"+string(bytestr.StrCRLF)+string(bytestr.StrCRLF)))
+}
+
+func TestNewChunkedBodyWriter1(t *testing.T) {
+	response := protocol.AcquireResponse()
+	mockConn := mock.NewConn("")
+	w := NewChunkedBodyWriter(response, mockConn)
+	w.Write([]byte("hello"))
+	w.Flush()
+	w.Finalize()
+	w.Flush()
+	out, _ := mockConn.WriterRecorder().ReadBinary(mockConn.WriterRecorder().WroteLen())
+	assert.True(t, strings.Contains(string(out), "Transfer-Encoding: chunked"))
+	assert.True(t, strings.Contains(string(out), "5"+string(bytestr.StrCRLF)+"hello"))
+	assert.True(t, strings.Contains(string(out), "0"+string(bytestr.StrCRLF)+string(bytestr.StrCRLF)))
+}

--- a/pkg/protocol/http1/server.go
+++ b/pkg/protocol/http1/server.go
@@ -413,6 +413,11 @@ func writeErrorResponse(zw network.Writer, ctx *app.RequestContext, serverName [
 }
 
 func writeResponse(ctx *app.RequestContext, w network.Writer) error {
+	// Skip default response writing logic if it has been hijacked
+	if ctx.Response.GetHijackWriter() != nil {
+		return ctx.Response.GetHijackWriter().Finalize()
+	}
+
 	err := resp.Write(&ctx.Response, w)
 	if err != nil {
 		return err

--- a/pkg/protocol/http1/server_test.go
+++ b/pkg/protocol/http1/server_test.go
@@ -23,9 +23,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/cloudwego/hertz/pkg/protocol"
-	"github.com/cloudwego/hertz/pkg/protocol/http1/resp"
-
 	inStats "github.com/cloudwego/hertz/internal/stats"
 	"github.com/cloudwego/hertz/pkg/app"
 	errs "github.com/cloudwego/hertz/pkg/common/errors"
@@ -35,6 +32,8 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/tracer/stats"
 	"github.com/cloudwego/hertz/pkg/common/tracer/traceinfo"
 	"github.com/cloudwego/hertz/pkg/network"
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/cloudwego/hertz/pkg/protocol/http1/resp"
 )
 
 var pool = &sync.Pool{New: func() interface{} {

--- a/pkg/protocol/response.go
+++ b/pkg/protocol/response.go
@@ -47,7 +47,6 @@ import (
 	"sync"
 
 	"github.com/cloudwego/hertz/internal/bytesconv"
-
 	"github.com/cloudwego/hertz/internal/nocopy"
 	"github.com/cloudwego/hertz/pkg/common/bytebufferpool"
 	"github.com/cloudwego/hertz/pkg/common/compress"

--- a/pkg/protocol/response.go
+++ b/pkg/protocol/response.go
@@ -46,6 +46,8 @@ import (
 	"net"
 	"sync"
 
+	"github.com/cloudwego/hertz/internal/bytesconv"
+
 	"github.com/cloudwego/hertz/internal/nocopy"
 	"github.com/cloudwego/hertz/pkg/common/bytebufferpool"
 	"github.com/cloudwego/hertz/pkg/common/compress"
@@ -90,6 +92,17 @@ type Response struct {
 	raddr net.Addr
 	// Local TCPAddr from concurrently net.Conn
 	laddr net.Addr
+
+	// If set a hijackWriter, hertz will skip the default header/body writer process.
+	hijackWriter network.ExtWriter
+}
+
+func (resp *Response) GetHijackWriter() network.ExtWriter {
+	return resp.hijackWriter
+}
+
+func (resp *Response) HijackWriter(writer network.ExtWriter) {
+	resp.hijackWriter = writer
 }
 
 type responseBodyWriter struct {
@@ -133,7 +146,7 @@ func (resp *Response) ConstructBodyStream(body *bytebufferpool.ByteBuffer, bodyS
 // BodyWriter returns writer for populating response body.
 //
 // If used inside RequestHandler, the returned writer must not be used
-// after returning from RequestHandler. Use RequestCtx.Write
+// after returning from RequestHandler. Use RequestContext.Write
 // or SetBodyStreamWriter in this case.
 func (resp *Response) BodyWriter() io.Writer {
 	resp.w.r = resp
@@ -265,6 +278,7 @@ func (resp *Response) Reset() {
 	resp.raddr = nil
 	resp.laddr = nil
 	resp.ImmediateHeaderFlush = false
+	resp.hijackWriter = nil
 }
 
 func (resp *Response) resetSkipHeader() {
@@ -314,13 +328,21 @@ func (resp *Response) BodyStream() io.Reader {
 //
 // It is safe re-using p after the function returns.
 func (resp *Response) AppendBody(p []byte) {
-	resp.CloseBodyStream()     //nolint:errcheck
+	resp.CloseBodyStream() //nolint:errcheck
+	if resp.hijackWriter != nil {
+		resp.hijackWriter.Write(p) //nolint:errcheck
+		return
+	}
 	resp.BodyBuffer().Write(p) //nolint:errcheck
 }
 
 // AppendBodyString appends s to response body.
 func (resp *Response) AppendBodyString(s string) {
-	resp.CloseBodyStream()           //nolint:errcheck
+	resp.CloseBodyStream() //nolint:errcheck
+	if resp.hijackWriter != nil {
+		resp.hijackWriter.Write(bytesconv.S2b(s)) //nolint:errcheck
+		return
+	}
 	resp.BodyBuffer().WriteString(s) //nolint:errcheck
 }
 

--- a/pkg/protocol/response_test.go
+++ b/pkg/protocol/response_test.go
@@ -48,11 +48,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cloudwego/hertz/pkg/common/test/mock"
-
 	"github.com/cloudwego/hertz/pkg/common/bytebufferpool"
 	"github.com/cloudwego/hertz/pkg/common/compress"
 	"github.com/cloudwego/hertz/pkg/common/test/assert"
+	"github.com/cloudwego/hertz/pkg/common/test/mock"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
 


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
支持在handler中按chunk flush数据

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: 
1. Support hijack for writer of response
2. Provide a impl for chunk-flushing writer for http/1.1

zh(optional):
1. response 支持writer劫持
2. 提供一个支持按chunk块flush的writer实现

#### Which issue(s) this PR fixes:
None
