### PR TITLE
fix: switch Trailer to pointer to avoid cycle dependencies

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -87,7 +87,7 @@ type RequestHeader struct {
 
 	h       []argsKV
 	bufKV   argsKV
-	trailer Trailer
+	trailer *Trailer
 
 	cookies []argsKV
 
@@ -127,7 +127,7 @@ type ResponseHeader struct {
 
 	h       []argsKV
 	bufKV   argsKV
-	trailer Trailer
+	trailer *Trailer
 
 	cookies []argsKV
 
@@ -1788,10 +1788,16 @@ func (h *RequestHeader) setSpecialHeader(key, value []byte) bool {
 
 // Trailer returns the Trailer of HTTP Header.
 func (h *ResponseHeader) Trailer() *Trailer {
-	return &h.trailer
+	if h.trailer == nil {
+		h.trailer = new(Trailer)
+	}
+	return h.trailer
 }
 
 // Trailer returns the Trailer of HTTP Header.
 func (h *RequestHeader) Trailer() *Trailer {
-	return &h.trailer
+	if h.trailer == nil {
+		h.trailer = new(Trailer)
+	}
+	return h.trailer
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
将 `Header` 中的 `Trailer` 改为指针以避免循环依赖

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: There will be `*Trailer` in `bodyStream`, thus implicitly referencing `Response`, resulting in a circular dependency between `bodyStream` and `Response`, thus making `runtime.SetFinalizer` not work properly, change Trailer to `*Trailer` to avoid circular dependencies
zh(optional): 在 `bodyStream` 中会存在 `*Trailer`，从而隐式引用了 `Response`，导致 `bodyStream` 与 `Response` 循环依赖，从而使 `runtime.SetFinalizer` 不能正常工作，将 Trailer 改为 `*Trailer` 以避免循环依赖

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
