### PR TITLE
fix: header add trailer will panic

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -1768,6 +1768,8 @@ func (h *RequestHeader) setSpecialHeader(key, value []byte) bool {
 			// Transfer-Encoding is managed automatically.
 			return true
 		} else if utils.CaseInsensitiveCompare(bytestr.StrTrailer, key) {
+			// copy value to avoid panic
+			value = append(h.bufKV.value[:0], value...)
 			h.Trailer().SetTrailers(value)
 			return true
 		}

--- a/pkg/protocol/trailer_test.go
+++ b/pkg/protocol/trailer_test.go
@@ -36,6 +36,42 @@ func TestTrailerAdd(t *testing.T) {
 	assert.True(t, strings.Contains(string(tr.Header()), "Bar: value3"))
 }
 
+func TestHeaderTrailerSet(t *testing.T) {
+	h := &RequestHeader{}
+
+	// only one trailer
+	h.Set("Trailer", "Foo")
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Foo:"))
+
+	// multi trailer
+	h.Set("Trailer", "Foo, bar, HERtz")
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Foo:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Bar:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Hertz:"))
+
+	// all lowercase
+	h.Set("Trailer", "foo,hertz,aaa")
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Foo:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Hertz:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Aaa:"))
+
+	// all uppercase
+	h.Set("Trailer", "FOO,HERTZ,AAA")
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Foo:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Hertz:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Aaa:"))
+
+	// with '-'
+	h.Set("Trailer", "FOO-HERTZ-AAA")
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Foo-Hertz-Aaa:"))
+
+	// more space
+	h.Set("Trailer", "      foo,      hertz       ,        aaa      ")
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Foo:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Hertz:"))
+	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Aaa:"))
+}
+
 func TestTrailerAddError(t *testing.T) {
 	var tr Trailer
 	assert.NotNil(t, tr.Add(consts.HeaderContentType, ""))


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复 Header 添加 Trailer 时 panic 的 bug

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: When header add only one Trailer with `Header.Set("Trailer", "foo")`, it will panic. Because the []byte cannot be changed after the string is forcely converted.
zh(optional): Header 使用 `Header.Set("Trailer", "foo")` 只添加一个 Trailer 的时候，因为 string 强转之后的 []byte 不能被更改，所以会造成 panic

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
