### PR TITLE
feat(hz): search go mod

### DIFF
--- a/cmd/hz/app/app.go
+++ b/cmd/hz/app/app.go
@@ -69,6 +69,10 @@ func New(c *cli.Context) error {
 	if err != nil {
 		return cli.Exit(fmt.Errorf("persist manifest failed: %v", err), meta.PersistError)
 	}
+	if !args.NeedGoMod && args.IsNew() {
+		fmt.Println(meta.AddThriftReplace)
+	}
+
 	return nil
 }
 
@@ -243,6 +247,7 @@ func Init() *cli.App {
 				&handlerDirFlag,
 				&modelDirFlag,
 				&clientDirFlag,
+				&useFlag,
 
 				&includesFlag,
 				&thriftOptionsFlag,
@@ -270,7 +275,6 @@ func Init() *cli.App {
 				&moduleFlag,
 				&outDirFlag,
 				&modelDirFlag,
-				&useFlag,
 
 				&includesFlag,
 				&thriftOptionsFlag,
@@ -340,6 +344,7 @@ func GenerateLayout(args *config.Argument) error {
 		ModelDir:        args.ModelDir,
 		HandlerDir:      args.HandlerDir,
 		RouterDir:       args.RouterDir,
+		NeedGoMod:       args.NeedGoMod,
 	}
 
 	if args.CustomizeLayout == "" {

--- a/cmd/hz/generator/layout.go
+++ b/cmd/hz/generator/layout.go
@@ -36,6 +36,7 @@ type Layout struct {
 	ServiceName     string
 	UseApacheThrift bool
 	HasIdl          bool
+	NeedGoMod       bool
 	ModelDir        string
 	HandlerDir      string
 	RouterDir       string
@@ -117,6 +118,13 @@ func (lg *LayoutGenerator) GenerateByService(service Layout) error {
 			delete(lg.tpls, defaultRegisterDir)
 			newRegisterDir := filepath.Clean(service.RouterDir + sp + registerTplName)
 			lg.tpls[newRegisterDir] = tpl
+		}
+	}
+
+	if !service.NeedGoMod {
+		gomodFile := "go.mod"
+		if _, exist := lg.tpls["go.mod"]; exist {
+			delete(lg.tpls, gomodFile)
 		}
 	}
 

--- a/cmd/hz/meta/const.go
+++ b/cmd/hz/meta/const.go
@@ -84,3 +84,5 @@ const (
 
 // TheUseOptionMessage indicates that the generating of 'model code' is aborted due to the -use option for thrift IDL.
 const TheUseOptionMessage = "'model code' is not generated due to the '-use' option"
+
+const AddThriftReplace = "do not generate 'go.mod', please add 'replace github.com/apache/thrift => github.com/apache/thrift v0.13.0' to your 'go.mod'"


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
增加搜索 "go.mod" 的功能，使得 go.mod 不必放在项目里

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: Add the ability to search for "go.mod" so that go.mod doesn't have to be in the project
zh(optional): 增加搜索 "go.mod" 的功能，使得 go.mod 不必放在项目里
具体行为：
- 不区分 gopath/non-gopath
- 如果命令行指定 "mod"，则默认使用这个作为项目 module 名
- 如果命令行不指定 "mod"，则一直向上层目录搜索，直到找到 "go.mod"，并用其作为 module 名；如果没找到，则使用与 gopath 的相对路径作为 module 名(非gopath下会报错提示)

Specific behavior.
- Does not distinguish between gopath/non-gopath
- If "mod" is specified on the command line, this will be used as the project module name by default
- If "mod" is not specified on the command line, keep searching to the upper directory until you find "go.mod" and use it as the module name; if not, use the relative path to gopath as the module name (an error will be reported under non-gopath)

Translated with www.DeepL.com/Translator (free version)
#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
