### PR TITLE
fix(hz): protobuf omitempty lose

### DIFF
--- a/cmd/hz/protobuf/tags.go
+++ b/cmd/hz/protobuf/tags.go
@@ -270,10 +270,10 @@ func reflectJsonTag(f protoreflect.FieldDescriptor) (ret model.Tag) {
 	if v := checkFirstOption(api.E_Body, f.Options()); v != nil {
 		ret.Value += ",string"
 	}
-	if !unsetOmitempty && descriptorpb.FieldDescriptorProto_Label(f.Cardinality()) == descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL {
-		ret.Value += ",omitempty"
-	} else if descriptorpb.FieldDescriptorProto_Label(f.Cardinality()) == descriptorpb.FieldDescriptorProto_LABEL_REQUIRED {
+	if descriptorpb.FieldDescriptorProto_Label(f.Cardinality()) == descriptorpb.FieldDescriptorProto_LABEL_REQUIRED {
 		ret.Value += ",required"
+	} else if !unsetOmitempty {
+		ret.Value += ",omitempty"
 	}
 	return
 }
@@ -383,10 +383,11 @@ func getStructJsonValue(f protoreflect.FieldDescriptor, val string) string {
 	if v := checkFirstOption(api.E_JsConv, f.Options()); v != nil {
 		val += ",string"
 	}
-	if !unsetOmitempty && descriptorpb.FieldDescriptorProto_Label(f.Cardinality()) == descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL {
-		val += ",omitempty"
-	} else if descriptorpb.FieldDescriptorProto_Label(f.Cardinality()) == descriptorpb.FieldDescriptorProto_LABEL_REQUIRED {
+
+	if descriptorpb.FieldDescriptorProto_Label(f.Cardinality()) == descriptorpb.FieldDescriptorProto_LABEL_REQUIRED {
 		val += ",required"
+	} else if !unsetOmitempty {
+		val += ",omitempty"
 	}
 
 	return val


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
修复 protobuf 生成的 tag 缺少 "omitempty" 选项

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: Fix missing "omitempty" option for protobuf-generated tags
zh(optional): 修复 protobuf 生成的 tag 缺少 "omitempty" 选项

protoc-gen-go 针对所以的 field 都生成了一个 json 的 "omitempty" 选项。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
