### PR TITLE
[WIP]feat(hz): search struct field for hz client

### DIFF
--- a/cmd/hz/app/app.go
+++ b/cmd/hz/app/app.go
@@ -188,6 +188,7 @@ func Init() *cli.App {
 	customLayoutData := cli.StringFlag{Name: "customize_layout_data_path", Usage: "Specify the path for layout template render data.", Destination: &globalArgs.CustomizeLayoutData}
 	customPackage := cli.StringFlag{Name: "customize_package", Usage: "Specify the path for package template.", Destination: &globalArgs.CustomizePackage}
 	handlerByMethod := cli.BoolFlag{Name: "handler_by_method", Usage: "Generate a separate handler file for each method.", Destination: &globalArgs.HandlerByMethod}
+	setDefaultQueryFlag := cli.BoolFlag{Name: "set_default_query", Usage: "Set query parameters for field that has no tags.", Destination: &globalArgs.SetDefaultQuery}
 
 	// app
 	app := cli.NewApp()
@@ -313,6 +314,7 @@ func Init() *cli.App {
 				&protoCamelJSONTag,
 				&snakeNameFlag,
 				&excludeFilesFlag,
+				&setDefaultQueryFlag,
 				&protoPluginsFlag,
 				&thriftPluginsFlag,
 			},

--- a/cmd/hz/config/argument.go
+++ b/cmd/hz/config/argument.go
@@ -68,6 +68,7 @@ type Argument struct {
 	NoRecurse            bool
 	HandlerByMethod      bool
 	ForceNew             bool
+	SetDefaultQuery      bool
 
 	CustomizeLayout     string
 	CustomizeLayoutData string

--- a/cmd/hz/config/cmd.go
+++ b/cmd/hz/config/cmd.go
@@ -222,5 +222,8 @@ func (arg *Argument) GetThriftgoOptions() (string, error) {
 		arg.ThriftOptions = append(arg.ThriftOptions, "json_enum_as_text")
 	}
 	gas := "go:" + strings.Join(arg.ThriftOptions, ",") + ",reserve_comments,gen_json_tag=false"
+	if arg.CmdType == meta.CmdClient {
+		gas += ",nil_safe"
+	}
 	return gas, nil
 }

--- a/cmd/hz/generator/client.go
+++ b/cmd/hz/generator/client.go
@@ -50,10 +50,6 @@ func (pkgGen *HttpPackageGenerator) genClient(pkg *HttpPackage, clientDir string
 			cliDir = pkgGen.ForceClientDir
 		}
 		hertzClientPath := filepath.Join(cliDir, hertzClientTplName)
-		isExist, err := util.PathExist(hertzClientPath)
-		if err != nil {
-			return err
-		}
 		baseDomain := s.BaseDomain
 		if len(pkgGen.BaseDomain) != 0 {
 			baseDomain = pkgGen.BaseDomain
@@ -65,11 +61,9 @@ func (pkgGen *HttpPackageGenerator) genClient(pkg *HttpPackage, clientDir string
 			ClientMethods: s.ClientMethods,
 			BaseDomain:    baseDomain,
 		}
-		if !isExist {
-			err := pkgGen.TemplateGenerator.Generate(client, hertzClientTplName, hertzClientPath, false)
-			if err != nil {
-				return err
-			}
+		err := pkgGen.TemplateGenerator.Generate(client, hertzClientTplName, hertzClientPath, false)
+		if err != nil {
+			return err
 		}
 		client.Imports = make(map[string]*model.Model, len(client.ClientMethods))
 		for _, m := range client.ClientMethods {

--- a/cmd/hz/generator/package_tpl.go
+++ b/cmd/hz/generator/package_tpl.go
@@ -596,9 +596,16 @@ func (r *request) setHeaders(headers map[string]string) *request {
 	return r
 }
 
-func (r *request) setQueryParams(params map[string]interface{}) *request {
-	for p, v := range params {
-		r.setQueryParam(p, v)
+type queryParam struct {
+	Key string
+	Value interface{}
+}
+
+type queryParams []queryParam
+
+func (r *request) setQueryParams(params queryParams) *request {
+	for _, param := range params {
+		r.setQueryParam(param.Key, param.Value)
 	}
 
 	return r
@@ -897,7 +904,7 @@ func (s *{{$.ServiceName}}Client) {{$MethodInfo.Name}}(context context.Context, 
 	httpResp := &{{$MethodInfo.ReturnTypeName}}{}	
 	ret, err := s.client.r().
 		setContext(context).
-		setQueryParams(map[string]interface{}{
+		setQueryParams(queryParams{
 			{{$MethodInfo.QueryParamsCode}}
 		}).
 		setPathParams(map[string]string{

--- a/cmd/hz/protobuf/plugin.go
+++ b/cmd/hz/protobuf/plugin.go
@@ -544,7 +544,7 @@ func (plugin *Plugin) getIdlInfo(ast *descriptorpb.FileDescriptorProto, deps map
 		return nil, err
 	}
 
-	services, err := astToService(ast, rs, args.CmdType, plugin.Plugin)
+	services, err := astToService(ast, rs, args, plugin.Plugin)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/hz/thrift/plugin.go
+++ b/cmd/hz/thrift/plugin.go
@@ -291,7 +291,7 @@ func (plugin *Plugin) getPackageInfo() (*generator.HttpPackage, error) {
 		return nil, fmt.Errorf("go package for '%s' is not defined", ast.GetFilename())
 	}
 
-	services, err := astToService(ast, rs, args.CmdType)
+	services, err := astToService(ast, rs, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
hz client 添加搜索 struct field 的能力

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: hz client adds the ability to search struct fields
zh(optional): hz client 添加搜索 struct field 的能力

主要变更：
- 添加选项 "set_default_query"，添加这个会将get请求中没定义 tag 的 field 默认放到 query 参数中
- thrift/protobuf IDL 添加递归搜索 "struct" 类型的 field，使得可将 http 信息放到嵌套的结构体中，更易管理
- 修改默认的 client 生成模板，将 "setQueryParams" 的参数由"map"变更为"slice"，防止出现 query 的 "key" 相同的情况
- 生成链式调用getter函数，需要注意空指针导致的 panic 问题，这块生成代码先不特殊处理，使用 thriftgo 的 "nil_safe" 选项来生成，不会空指针的 getter 函数。(client 侧的 model 需要设置为默认形式)

Main changes:
- Add option "set_default_query", adding this will put fields without tag defined in the get request into the query parameter by default
- thrift/protobuf IDL adds recursive search for fields of type "struct", making it possible to put http information into nested structs for easier management
- Modify the default client generation template to change the parameter of "setQueryParams" from "map" to "slice" to prevent the case that the "key" of the query is the same.



#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
