### PR TITLE
[WIP]feat(hz): support extending service for thrift

### DIFF
--- a/cmd/hz/app/app.go
+++ b/cmd/hz/app/app.go
@@ -179,6 +179,7 @@ func Init() *cli.App {
 	protoPluginsFlag := cli.StringSliceFlag{Name: "protoc-plugins", Usage: "Specify plugins for the protoc. ({plugin_name}:{options}:{out_dir})"}
 	noRecurseFlag := cli.BoolFlag{Name: "no_recurse", Usage: "Generate master model only.", Destination: &globalArgs.NoRecurse}
 	forceNewFlag := cli.BoolFlag{Name: "force", Aliases: []string{"f"}, Usage: "Force new a project, which will overwrite the generated files", Destination: &globalArgs.ForceNew}
+	enableExtendsFlag := cli.BoolFlag{Name: "enable_extends", Usage: "Parse 'extends' for thrift IDL", Destination: &globalArgs.EnableExtends}
 
 	jsonEnumStrFlag := cli.BoolFlag{Name: "json_enumstr", Usage: "Use string instead of num for json enums when idl is thrift.", Destination: &globalArgs.JSONEnumStr}
 	unsetOmitemptyFlag := cli.BoolFlag{Name: "unset_omitempty", Usage: "Remove 'omitempty' tag for generated struct.", Destination: &globalArgs.UnsetOmitempty}
@@ -224,6 +225,7 @@ func Init() *cli.App {
 				&optPkgFlag,
 				&noRecurseFlag,
 				&forceNewFlag,
+				&enableExtendsFlag,
 
 				&jsonEnumStrFlag,
 				&unsetOmitemptyFlag,
@@ -256,6 +258,7 @@ func Init() *cli.App {
 				&protoOptionsFlag,
 				&optPkgFlag,
 				&noRecurseFlag,
+				&enableExtendsFlag,
 
 				&jsonEnumStrFlag,
 				&unsetOmitemptyFlag,
@@ -307,6 +310,7 @@ func Init() *cli.App {
 				&thriftOptionsFlag,
 				&protoOptionsFlag,
 				&noRecurseFlag,
+				&enableExtendsFlag,
 
 				&jsonEnumStrFlag,
 				&unsetOmitemptyFlag,

--- a/cmd/hz/config/argument.go
+++ b/cmd/hz/config/argument.go
@@ -68,6 +68,7 @@ type Argument struct {
 	NoRecurse            bool
 	HandlerByMethod      bool
 	ForceNew             bool
+	EnableExtends        bool
 
 	CustomizeLayout     string
 	CustomizeLayoutData string

--- a/cmd/hz/thrift/plugin.go
+++ b/cmd/hz/thrift/plugin.go
@@ -291,7 +291,7 @@ func (plugin *Plugin) getPackageInfo() (*generator.HttpPackage, error) {
 		return nil, fmt.Errorf("go package for '%s' is not defined", ast.GetFilename())
 	}
 
-	services, err := astToService(ast, rs, args.CmdType)
+	services, err := astToService(ast, rs, args)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
thrift IDL 增加对 extends 关键字的支持

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: support extending service for thrift
zh(optional): thrift IDL 增加对 extends 关键字的支持

```
service Service1 {}

service Service2 extends Service1 {}

service Service3 extends other.OtherService {}
```
主要变更：

- 增加 "enable_extends" 选项，开启 extends 可能会对之前的 IDL 的生成的默认行为产生不一致，因此需要加一个选项
- 在解析 service 的时候，将某一个 service1 继承的所有 service2 的方法都统一解析到当前 service 下(可能存在多层的基础，所以要递归)
- 之前解析的时候只考虑了 service 定义在 master IDL 的情况，而 extends 可将 service 的定义拓展到其他 IDL 文件中，因此在递归的时候需要增加对对应 ast 的解析

Main changes:

- Add "enable_extends" option. Turning on extends may cause inconsistency in the default behavior of the previous IDL generation, so it is necessary to add an option
- When parsing service, all methods of service2 inherited by a service1 will be unified under the current service (there may be multiple layers of base, so it should be recursive)
- The previous parsing only considered the case where the service is defined in the master IDL, but extends can extend the service definition to other IDL files, so you need to add the parsing of the corresponding ast in the recursion

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
