### PR TITLE
test: TestGcBodyStream will sleep 100ms to wait gc finish

### DIFF
--- a/pkg/protocol/http1/client_unix_test.go
+++ b/pkg/protocol/http1/client_unix_test.go
@@ -32,9 +32,9 @@ import (
 
 func TestGcBodyStream(t *testing.T) {
 	srv := &http.Server{Addr: ":11001", Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte("hello\n"))
-		time.Sleep(time.Second)
-		w.Write([]byte("world\n"))
+		for range [1024]int{} {
+			w.Write([]byte("hello world\n"))
+		}
 	})}
 	go srv.ListenAndServe()
 	time.Sleep(100 * time.Millisecond)
@@ -58,6 +58,8 @@ func TestGcBodyStream(t *testing.T) {
 	}
 
 	runtime.GC()
+	// wait for gc
+	time.Sleep(100 * time.Millisecond)
 	c.CloseIdleConnections()
 	assert.DeepEqual(t, 0, c.ConnPoolState().TotalConnNum)
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
test
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
TestGcBodyStream 将 sleep 100ms 等待 gc 结束

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: The execution process of `SetFinalizer` is asynchronous, so the connection may still be in an open state even after calling `runtime.Gc`. To avoid this error, sleeping for 100ms.
zh(optional): `SetFinalizer` 的执行过程是异步的，所以调用 `runtime.Gc` 之后，连接依旧有可能处于打开状态。 sleep 100ms 去避免出现此错误

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
