### PR TITLE
feat(route): provide api for customize engine.ServeHTTP

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -198,7 +198,7 @@ type Engine struct {
 
 func (engine *Engine) SetCustomServeHTTP(f app.HandlerFunc) {
 	if engine.IsRunning() {
-		hlog.SystemLogger().Errorf("engine is running, can not set custom serve http")
+		hlog.SystemLogger().Errorf("engine is running, can not set custom ServeHTTP handler")
 	}
 	engine.customServeHTTP = f
 }

--- a/pkg/route/routes_timing_test.go
+++ b/pkg/route/routes_timing_test.go
@@ -652,7 +652,8 @@ func BenchmarkRouteAny(b *testing.B) {
 	req.CopyTo(&ctx.Request)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		req.CopyTo(&ctx.Request)
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.ResetWithoutConn()
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
路由层暴露 API，提供自定义 ServeHTTP 逻辑

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: This api provides a more flexible way to integrate hertz - build applications based on Hertz's protocol layer and network layer
zh(optional): 提供一个更加灵活集成hertz的方式：基于hertz的协议层和网络层构建应用

#### Which issue(s) this PR fixes:
None