### PR TITLE
fix: DoDeadline doesn't cost ch in error case

### DIFF
--- a/pkg/protocol/client/client.go
+++ b/pkg/protocol/client/client.go
@@ -348,6 +348,11 @@ func DoDeadline(ctx context.Context, req *protocol.Request, resp *protocol.Respo
 	}
 	timer.ReleaseTimer(tc)
 
+	select {
+	case <-ch:
+	default:
+	}
+
 	errorChPool.Put(chv)
 
 	return err


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
DoDeadline 在异常情况下没有消费 ch 里的数据

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: DoDeadline doesn't cost ch in error case. When the timeout time is close to the request time, the data in ch may not be consumed, causing the next request to get the resp string package of the previous request.
zh(optional): DoDeadline 在异常情况下没有消费 ch 里的数据。当超时时间和请求时间接近时，可能导致 ch 中的数据没有被消费掉，导致下一次请求拿到上一次请求的 resp 串包。

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
