### PR TITLE
optimize: DialTimeout provided by netpoll will return TLS err directly

### DIFF
--- a/pkg/network/netpoll/dial.go
+++ b/pkg/network/netpoll/dial.go
@@ -46,7 +46,6 @@ func (d dialer) DialConnection(n, address string, timeout time.Duration, tlsConf
 
 func (d dialer) DialTimeout(network, address string, timeout time.Duration, tlsConfig *tls.Config) (conn net.Conn, err error) {
 	if tlsConfig != nil {
-		// https
 		return nil, errNotSupportTLS
 	}
 	conn, err = d.Dialer.DialTimeout(network, address, timeout)

--- a/pkg/network/netpoll/dial.go
+++ b/pkg/network/netpoll/dial.go
@@ -45,6 +45,10 @@ func (d dialer) DialConnection(n, address string, timeout time.Duration, tlsConf
 }
 
 func (d dialer) DialTimeout(network, address string, timeout time.Duration, tlsConfig *tls.Config) (conn net.Conn, err error) {
+	if tlsConfig != nil {
+		// https
+		return nil, errNotSupportTLS
+	}
 	conn, err = d.Dialer.DialTimeout(network, address, timeout)
 	return
 }

--- a/pkg/network/netpoll/dial_test.go
+++ b/pkg/network/netpoll/dial_test.go
@@ -65,5 +65,7 @@ func TestDial(t *testing.T) {
 		assert.DeepEqual(t, errNotSupportTLS, err)
 		_, err = dial.DialConnection("tcp", "localhost:10102", time.Microsecond, &tls.Config{})
 		assert.DeepEqual(t, errNotSupportTLS, err)
+		_, err = dial.DialTimeout("tcp", "localhost:10102", time.Microsecond, &tls.Config{})
+		assert.DeepEqual(t, errNotSupportTLS, err)
 	})
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: netpoll return the "not support tls" error instead. refer to https://github.com/cloudwego/hertz/pull/672#issuecomment-1475864569
zh(optional): netpoll 返回不支持 tls 的错误信息。 参考 https://github.com/cloudwego/hertz/pull/672#issuecomment-1475864569



#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
