### PR TITLE
feat(route): support for ignore static file server route prefixes

### DIFF
--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -346,3 +346,11 @@ func WithOnConnect(fn func(ctx context.Context, conn network.Conn) context.Conte
 		o.OnConnect = fn
 	}}
 }
+
+// WithCleanStaticFSPrefix sets whether enable clean router prefix in RouterGroup.StaticFS.
+// If we don't set it, it will default to false
+func WithCleanStaticFSPrefix(b bool) config.Option {
+	return config.Option{F: func(o *config.Options) {
+		o.CleanStaticFSPrefix = b
+	}}
+}

--- a/pkg/app/server/option_test.go
+++ b/pkg/app/server/option_test.go
@@ -62,6 +62,7 @@ func TestOptions(t *testing.T) {
 		WithTraceLevel(stats.LevelDisabled),
 		WithRegistry(nil, info),
 		WithAutoReloadRender(true, 5*time.Second),
+		WithCleanStaticFSPrefix(true),
 	})
 	assert.DeepEqual(t, opt.ReadTimeout, time.Second)
 	assert.DeepEqual(t, opt.WriteTimeout, time.Second)
@@ -92,6 +93,7 @@ func TestOptions(t *testing.T) {
 	assert.DeepEqual(t, opt.Registry, nil)
 	assert.DeepEqual(t, opt.AutoReloadRender, true)
 	assert.DeepEqual(t, opt.AutoReloadInterval, 5*time.Second)
+	assert.DeepEqual(t, opt.CleanStaticFSPrefix, true)
 }
 
 func TestDefaultOptions(t *testing.T) {
@@ -124,4 +126,5 @@ func TestDefaultOptions(t *testing.T) {
 	assert.Assert(t, opt.RegistryInfo == nil)
 	assert.DeepEqual(t, opt.AutoReloadRender, false)
 	assert.DeepEqual(t, opt.AutoReloadInterval, time.Duration(0))
+	assert.DeepEqual(t, opt.CleanStaticFSPrefix, false)
 }

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -61,6 +61,7 @@ type Options struct {
 	StreamRequestBody            bool
 	NoDefaultServerHeader        bool
 	DisablePrintRoute            bool
+	CleanStaticFSPrefix          bool
 	Network                      string
 	Addr                         string
 	BasePath                     string

--- a/pkg/route/routergroup.go
+++ b/pkg/route/routergroup.go
@@ -211,6 +211,8 @@ func (group *RouterGroup) StaticFS(relativePath string, fs *app.FS) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")
 	}
+	absolutePath := group.calculateAbsolutePath(relativePath)
+	fs.Prefix = absolutePath
 	handler := fs.NewRequestHandler()
 	urlPattern := path.Join(relativePath, "/*filepath")
 

--- a/pkg/route/routergroup.go
+++ b/pkg/route/routergroup.go
@@ -211,8 +211,11 @@ func (group *RouterGroup) StaticFS(relativePath string, fs *app.FS) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")
 	}
-	absolutePath := group.calculateAbsolutePath(relativePath)
-	fs.Prefix = absolutePath
+	if group.engine.options.CleanStaticFSPrefix {
+		absolutePath := group.calculateAbsolutePath(relativePath)
+		fs.Prefix = absolutePath
+	}
+
 	handler := fs.NewRequestHandler()
 	urlPattern := path.Join(relativePath, "/*filepath")
 

--- a/pkg/route/routergroup_test.go
+++ b/pkg/route/routergroup_test.go
@@ -149,6 +149,15 @@ func TestRouterGroupStatic(t *testing.T) {
 		router := NewEngine(config.NewOptions(nil))
 		router.Static("/prefix", ".")
 		w := performRequest(router, "GET", "/prefix/engine.go")
+		assert.DeepEqual(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("TestRelativePathWithCleanPrefix", func(t *testing.T) {
+		opt := config.NewOptions([]config.Option{})
+		opt.CleanStaticFSPrefix = true
+		router := NewEngine(opt)
+		router.Static("/prefix", ".")
+		w := performRequest(router, "GET", "/prefix/engine.go")
 		fd, err := os.Open("./engine.go")
 		if err != nil {
 			panic(err)
@@ -162,8 +171,10 @@ func TestRouterGroupStatic(t *testing.T) {
 		assert.DeepEqual(t, string(content), w.Body.String())
 	})
 
-	t.Run("TestRouterGroup", func(t *testing.T) {
-		router := NewEngine(config.NewOptions(nil))
+	t.Run("TestRouterGroupWithCleanPrefix", func(t *testing.T) {
+		opt := config.NewOptions([]config.Option{})
+		opt.CleanStaticFSPrefix = true
+		router := NewEngine(opt)
 		g := router.Group("/v1")
 		g.Static("/prefix", ".")
 		w := performRequest(router, "GET", "/v1/prefix/engine.go")

--- a/pkg/route/routergroup_test.go
+++ b/pkg/route/routergroup_test.go
@@ -128,20 +128,57 @@ func performRequestInGroup(t *testing.T, method string) {
 }
 
 func TestRouterGroupStatic(t *testing.T) {
-	router := NewEngine(config.NewOptions(nil))
-	router.Static("/", ".")
-	w := performRequest(router, "GET", "/engine.go")
-	fd, err := os.Open("./engine.go")
-	if err != nil {
-		panic(err)
-	}
-	assert.DeepEqual(t, http.StatusOK, w.Code)
-	defer fd.Close()
-	content, err := ioutil.ReadAll(fd)
-	if err != nil {
-		panic(err)
-	}
-	assert.DeepEqual(t, string(content), w.Body.String())
+	t.Run("TestNonRelativePath", func(t *testing.T) {
+		router := NewEngine(config.NewOptions(nil))
+		router.Static("/", ".")
+		w := performRequest(router, "GET", "/engine.go")
+		fd, err := os.Open("./engine.go")
+		if err != nil {
+			panic(err)
+		}
+		assert.DeepEqual(t, http.StatusOK, w.Code)
+		defer fd.Close()
+		content, err := ioutil.ReadAll(fd)
+		if err != nil {
+			panic(err)
+		}
+		assert.DeepEqual(t, string(content), w.Body.String())
+	})
+
+	t.Run("TestRelativePath", func(t *testing.T) {
+		router := NewEngine(config.NewOptions(nil))
+		router.Static("/prefix", ".")
+		w := performRequest(router, "GET", "/prefix/engine.go")
+		fd, err := os.Open("./engine.go")
+		if err != nil {
+			panic(err)
+		}
+		assert.DeepEqual(t, http.StatusOK, w.Code)
+		defer fd.Close()
+		content, err := ioutil.ReadAll(fd)
+		if err != nil {
+			panic(err)
+		}
+		assert.DeepEqual(t, string(content), w.Body.String())
+	})
+
+	t.Run("TestRouterGroup", func(t *testing.T) {
+		router := NewEngine(config.NewOptions(nil))
+		g := router.Group("/v1")
+		g.Static("/prefix", ".")
+		w := performRequest(router, "GET", "/v1/prefix/engine.go")
+		fd, err := os.Open("./engine.go")
+		if err != nil {
+			panic(err)
+		}
+		assert.DeepEqual(t, http.StatusOK, w.Code)
+		defer fd.Close()
+		content, err := ioutil.ReadAll(fd)
+		if err != nil {
+			panic(err)
+		}
+		assert.DeepEqual(t, string(content), w.Body.String())
+	})
 }
 
 func TestRouterGroupStaticFile(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
`RouterGroup.Static` 查找文件时没有处理路由前缀，增加选项去处理它

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: When we access `/static/1.png`, the file we should find for is `/var/www/1.png` not `/var/www/static/1.png`
```
	h.Static("/static", "/var/www")
```
zh(optional):
当我们访问 `/static/1.png` 时，我们应该找到的文件是 `/var/www/1.png` 而不是 `/var/www/static/1.png`。
```
	h.Static("/static", "/var/www")
```

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
