### PR TITLE
fix: stream client not close the conn when ConnectionClose is true

### DIFF
--- a/pkg/protocol/http1/client.go
+++ b/pkg/protocol/http1/client.go
@@ -623,7 +623,11 @@ func (c *HostClient) doNonNilReqResp(req *protocol.Request, resp *protocol.Respo
 		err = respI.ReadHeaderAndLimitBody(resp, zr, c.MaxResponseBodySize)
 	} else {
 		err = respI.ReadBodyStream(resp, zr, c.MaxResponseBodySize, func() error {
-			c.releaseConn(cc)
+			if resetConnection || req.ConnectionClose() || resp.ConnectionClose() {
+				c.closeConn(cc)
+			} else {
+				c.releaseConn(cc)
+			}
 			return nil
 		})
 	}

--- a/pkg/protocol/http1/client.go
+++ b/pkg/protocol/http1/client.go
@@ -619,11 +619,17 @@ func (c *HostClient) doNonNilReqResp(req *protocol.Request, resp *protocol.Respo
 	}
 	zr := c.acquireReader(conn)
 
+	// init here for passing in ReadBodyStream's closure
+	// and this value will be assigned after reading Response's Header
+	//
+	// This is to solve the circular dependency problem of Response and BodyStream
+	shouldCloseConn := false
+
 	if !c.ResponseBodyStream {
 		err = respI.ReadHeaderAndLimitBody(resp, zr, c.MaxResponseBodySize)
 	} else {
 		err = respI.ReadBodyStream(resp, zr, c.MaxResponseBodySize, func() error {
-			if resetConnection || req.ConnectionClose() || resp.ConnectionClose() {
+			if shouldCloseConn {
 				c.closeConn(cc)
 			} else {
 				c.releaseConn(cc)
@@ -642,11 +648,13 @@ func (c *HostClient) doNonNilReqResp(req *protocol.Request, resp *protocol.Respo
 
 	zr.Release() //nolint:errcheck
 
+	shouldCloseConn = resetConnection || req.ConnectionClose() || resp.ConnectionClose()
+
 	if c.ResponseBodyStream {
 		return false, err
 	}
 
-	if resetConnection || req.ConnectionClose() || resp.ConnectionClose() {
+	if shouldCloseConn {
 		c.closeConn(cc)
 	} else {
 		c.releaseConn(cc)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
client 在流式场景下，当 ConnectionClose 为 true 的时候，没有关闭链接

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
1. client uses streaming to receive resp, and is set to Connection: close
2. when the bodyStream is closed, the client does not determine if the connection is currently closed, but simply reuses the connection
3. the connection is closed by the server because of Connection: close
4. when the client sends a second request using this connection, it will report an error directly because the connection is closed


zh(optional): 存在这样一个场景：
1. client 使用流式接收 resp，且被设置了 Connection: close
2. 当 bodyStream 被关闭的时候，client 不会判断当前是否已经关闭了连接，而是直接将连接复用
3. 连接因为 Connection: close 被 server 关闭
4. 当 client 使用这个连接发送第二个请求的时候，会因为连接被关闭直接报错

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
