### PR TITLE
fix: RequestContext Value data race

### DIFF
--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -393,10 +393,6 @@ func (ctx *RequestContext) GetResponse() (dst *protocol.Response) {
 //
 // In case the Key is reset after response, Value() return nil if ctx.Key is nil.
 func (ctx *RequestContext) Value(key interface{}) interface{} {
-	// this ctx has been reset, return nil.
-	if ctx.Keys == nil {
-		return nil
-	}
 	if keyString, ok := key.(string); ok {
 		val, _ := ctx.Get(keyString)
 		return val

--- a/pkg/app/context_test.go
+++ b/pkg/app/context_test.go
@@ -80,6 +80,8 @@ func TestContext(t *testing.T) {
 	if ctx.Value("testContextKey") != "testValue" {
 		t.Fatalf("unexpected value: %#v, expected: %#v", ctx.Value("testContextKey"), "testValue")
 	}
+
+	ctx = NewContext(0)
 	assert.DeepEqual(t, ctx.Value("none"), nil)
 }
 

--- a/pkg/app/context_test.go
+++ b/pkg/app/context_test.go
@@ -80,6 +80,7 @@ func TestContext(t *testing.T) {
 	if ctx.Value("testContextKey") != "testValue" {
 		t.Fatalf("unexpected value: %#v, expected: %#v", ctx.Value("testContextKey"), "testValue")
 	}
+	assert.DeepEqual(t, ctx.Value("none"), nil)
 }
 
 func TestContextNotModified(t *testing.T) {
@@ -873,6 +874,25 @@ func TestContextSetGet(t *testing.T) {
 
 	assert.DeepEqual(t, "bar", c.MustGet("foo"))
 	assert.Panic(t, func() { c.MustGet("no_exist") })
+}
+
+func TestContextSetGetDataRace(t *testing.T) {
+	c := &RequestContext{}
+	go func() {
+		c.Set("foo", "bar")
+	}()
+
+	go func() {
+		c.Get("foo")
+	}()
+
+	go func() {
+		c.GetString("foo")
+	}()
+
+	go func() {
+		c.Value("foo")
+	}()
 }
 
 func TestContextSetGetValues(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.


#### (Optional) Translate the PR title into Chinese.
RequestContext.Value 有竞争问题

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: RequestContext.Value data race, similar APIs have locks on Get, only Value has this problem.

Actually `func (ctx *RequestContext) Value(key interface{}) interface{}`
Should be changed to `func (ctx *RequestContext) Value(key string) interface{}`
Because if it is not a string type, it will directly return nil, unfortunately it is a breaking change, and it seems that it can only be explained in the documentation.

zh(optional): RequestContext.Value 有竞争问题，类似的 API 会在 Get 上锁，只有 Value 有这个问题。

实际上 `func (ctx *RequestContext) Value(key interface{}) interface{}`
应该改成 `func (ctx *RequestContext) Value(key string) interface{} `
因为如果不是 string 类型会直接返回 nil，可惜是个破环更改，似乎只能在文档中说明。

related to [context/request.md#value](https://github.com/a631807682/cloudwego.github.io/blob/doc_context/content/zh/docs/hertz/tutorials/basic-feature/context/request.md#value)

#### Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
