### PR TITLE
fix: WriteMultipartFormFile will fail when the Reader return EOF at first Read

### DIFF
--- a/pkg/protocol/multipart.go
+++ b/pkg/protocol/multipart.go
@@ -137,11 +137,11 @@ func WriteMultipartFormFile(w *multipart.Writer, fieldName, fileName string, r i
 	// Auto detect actual multipart content type
 	cbuf := make([]byte, 512)
 	size, err := r.Read(cbuf)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return err
 	}
 
-	partWriter, err := w.CreatePart(CreateMultipartHeader(fieldName, fileName, http.DetectContentType(cbuf)))
+	partWriter, err := w.CreatePart(CreateMultipartHeader(fieldName, fileName, http.DetectContentType(cbuf[:size])))
 	if err != nil {
 		return err
 	}

--- a/pkg/protocol/multipart_test.go
+++ b/pkg/protocol/multipart_test.go
@@ -208,6 +208,9 @@ func TestWriteMultipartFormFile(t *testing.T) {
 		t.Fatalf("write multipart error: %s", err)
 	}
 	assert.False(t, strings.Contains(bodyBuffer.String(), f3.Name()))
+
+	// test empty file
+	assert.Nil(t, WriteMultipartFormFile(w, "empty_test", "test.data", bytes.NewBuffer(nil)))
 }
 
 func TestMarshalMultipartForm(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
修复：当传入的 `Reader` 的第一次 `Read` 返回 EOF 时，`WriteMultipartFormFile`将会失败

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: `WriteMultipartFormFile` does not check whether the return of Read is EOF. When Read returns EOF, `WriteMultipartForm` will return an error. Replace Read with `io.LimitedReader` to fix this
zh(optional): `WriteMultipartFormFile` 没有检查 Read 的返回是否是 EOF，当 Read 返回了 EOF 时， `WriteMultipartForm` 将会返回错误。将 Read 替换为 `io.LimitedReader` 来修复此问题

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/cloudwego/hertz/issues/746

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
