### PR TITLE
feat: add GetProtocol and SetProtocol api for ResponseHeader

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -180,9 +180,10 @@ func (h *ResponseHeader) PeekArgBytes(key []byte) []byte {
 func (h *ResponseHeader) SetNoHTTP11(b bool) {
 	if b {
 		h.protocol = consts.HTTP10
-	} else {
-		h.protocol = consts.HTTP11
+		return
 	}
+
+	h.protocol = consts.HTTP11
 }
 
 // Cookie fills cookie for the given cookie.Key.
@@ -314,9 +315,10 @@ func (h *RequestHeader) GetProtocol() string {
 func (h *RequestHeader) SetNoHTTP11(b bool) {
 	if b {
 		h.protocol = consts.HTTP10
-	} else {
-		h.protocol = consts.HTTP11
+		return
 	}
+
+	h.protocol = consts.HTTP11
 }
 
 func (h *RequestHeader) InitBufValue(size int) {

--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -112,6 +112,7 @@ type ResponseHeader struct {
 
 	disableNormalizing   bool
 	noHTTP11             bool
+	protocol             string
 	connectionClose      bool
 	noDefaultContentType bool
 	noDefaultDate        bool
@@ -487,6 +488,7 @@ func checkWriteHeaderCode(code int) {
 
 func (h *ResponseHeader) ResetSkipNormalize() {
 	h.noHTTP11 = false
+	h.protocol = ""
 	h.connectionClose = false
 
 	h.statusCode = 0
@@ -1802,4 +1804,12 @@ func (h *RequestHeader) Trailer() *Trailer {
 		h.trailer = new(Trailer)
 	}
 	return h.trailer
+}
+
+func (h *ResponseHeader) SetProtocol(p string) {
+	h.protocol = p
+}
+
+func (h *ResponseHeader) GetProtocol() string {
+	return h.protocol
 }

--- a/pkg/protocol/header_test.go
+++ b/pkg/protocol/header_test.go
@@ -70,18 +70,18 @@ func TestResponseHeaderSetHeaderLength(t *testing.T) {
 func TestSetNoHTTP11(t *testing.T) {
 	rh := ResponseHeader{}
 	rh.SetNoHTTP11(true)
-	assert.True(t, rh.noHTTP11)
+	assert.DeepEqual(t, consts.HTTP10, rh.protocol)
 
 	rh.SetNoHTTP11(false)
-	assert.False(t, rh.noHTTP11)
+	assert.DeepEqual(t, consts.HTTP11, rh.protocol)
 	assert.True(t, rh.IsHTTP11())
 
 	h := RequestHeader{}
 	h.SetNoHTTP11(true)
-	assert.True(t, h.noHTTP11)
+	assert.DeepEqual(t, consts.HTTP10, h.protocol)
 
 	h.SetNoHTTP11(false)
-	assert.False(t, h.noHTTP11)
+	assert.DeepEqual(t, consts.HTTP11, h.protocol)
 	assert.True(t, h.IsHTTP11())
 }
 

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -153,13 +153,11 @@ func parseFirstLine(h *protocol.RequestHeader, buf []byte) (int, error) {
 	// parse requestURI
 	n = bytes.LastIndexByte(b, ' ')
 	if n < 0 {
-		h.SetNoHTTP11(true)
 		h.SetProtocol(consts.HTTP10)
 		n = len(b)
 	} else if n == 0 {
 		return 0, fmt.Errorf("requestURI cannot be empty in %q", buf)
 	} else if !bytes.Equal(b[n+1:], bytestr.StrHTTP11) {
-		h.SetNoHTTP11(true)
 		h.SetProtocol(consts.HTTP10)
 	}
 	h.SetRequestURIBytes(b[:n])

--- a/pkg/protocol/http1/resp/header.go
+++ b/pkg/protocol/http1/resp/header.go
@@ -239,7 +239,15 @@ func parseFirstLine(h *protocol.ResponseHeader, buf []byte) (int, error) {
 	if n < 0 {
 		return 0, fmt.Errorf("cannot find whitespace in the first line of response %q", buf)
 	}
-	h.SetNoHTTP11(!bytes.Equal(b[:n], bytestr.StrHTTP11))
+
+	isHTTP11 := bytes.Equal(b[:n], bytestr.StrHTTP11)
+	h.SetNoHTTP11(!isHTTP11)
+	if !isHTTP11 {
+		h.SetProtocol(consts.HTTP10)
+	} else {
+		h.SetProtocol(consts.HTTP11)
+	}
+
 	b = b[n+1:]
 
 	// parse status code

--- a/pkg/protocol/http1/resp/header.go
+++ b/pkg/protocol/http1/resp/header.go
@@ -241,7 +241,6 @@ func parseFirstLine(h *protocol.ResponseHeader, buf []byte) (int, error) {
 	}
 
 	isHTTP11 := bytes.Equal(b[:n], bytestr.StrHTTP11)
-	h.SetNoHTTP11(!isHTTP11)
 	if !isHTTP11 {
 		h.SetProtocol(consts.HTTP10)
 	} else {


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
为 ResponseHeader 添加 GetProtocol 和 SetProtocol 接口

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: hertz client's Response lacks a quick and easy way to determine the HTTP version of the Response, so adding `SetProtocol` and `GetProtocol` allows the user to determine the HTTP version of the Response
zh(optional): hertz client 的 Response 缺乏一种快速简便的方式去判断这个 Response 的 HTTP 版本，所以添加`SetProtocol` 和`GetProtocol`让用户可以判断 Response 的 HTTP 版本

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
