### PR TITLE
fix: no copy some fields at ResponseHeader and RequestHeader

### DIFF
--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -243,6 +243,8 @@ func (h *ResponseHeader) CopyTo(dst *ResponseHeader) {
 	dst.server = append(dst.server[:0], h.server...)
 	dst.h = copyArgs(dst.h, h.h)
 	dst.cookies = copyArgs(dst.cookies, h.cookies)
+	dst.protocol = h.protocol
+	dst.headerLength = h.headerLength
 	h.Trailer().CopyTo(dst.Trailer())
 }
 
@@ -1107,6 +1109,7 @@ func (h *RequestHeader) CopyTo(dst *RequestHeader) {
 	dst.cookies = copyArgs(dst.cookies, h.cookies)
 	dst.cookiesCollected = h.cookiesCollected
 	dst.rawHeaders = append(dst.rawHeaders[:0], h.rawHeaders...)
+	dst.protocol = h.protocol
 }
 
 // Peek returns header value for the given key.

--- a/pkg/protocol/header_test.go
+++ b/pkg/protocol/header_test.go
@@ -656,3 +656,61 @@ func expectResponseHeaderAll(t *testing.T, h *ResponseHeader, key string, expect
 	}
 	assert.DeepEqual(t, h.PeekAll(key), expectedValue)
 }
+
+func TestRequestHeaderCopyTo(t *testing.T) {
+	t.Parallel()
+
+	h, hCopy := &RequestHeader{}, &RequestHeader{}
+	h.SetProtocol(consts.HTTP10)
+	h.SetMethod(consts.MethodPatch)
+	h.SetNoDefaultContentType(true)
+	h.Add(consts.HeaderConnection, "keep-alive")
+	h.Add("Content-Type", "aaa")
+	h.Add(consts.HeaderHost, "aaabbb")
+	h.Add("User-Agent", "asdfas")
+	h.Add("Content-Length", "1123")
+	h.Add("Cookie", "foobar=baz")
+	h.Add("aaa", "aaa")
+	h.Add("aaa", "bbb")
+
+	h.CopyTo(hCopy)
+	expectRequestHeaderAll(t, hCopy, consts.HeaderConnection, [][]byte{[]byte("keep-alive")})
+	expectRequestHeaderAll(t, hCopy, "Content-Type", [][]byte{[]byte("aaa")})
+	expectRequestHeaderAll(t, hCopy, consts.HeaderHost, [][]byte{[]byte("aaabbb")})
+	expectRequestHeaderAll(t, hCopy, "User-Agent", [][]byte{[]byte("asdfas")})
+	expectRequestHeaderAll(t, hCopy, "Content-Length", [][]byte{[]byte("1123")})
+	expectRequestHeaderAll(t, hCopy, "Cookie", [][]byte{[]byte("foobar=baz")})
+	expectRequestHeaderAll(t, hCopy, "aaa", [][]byte{[]byte("aaa"), []byte("bbb")})
+	assert.DeepEqual(t, hCopy.GetProtocol(), consts.HTTP10)
+	assert.DeepEqual(t, hCopy.noDefaultContentType, true)
+	assert.DeepEqual(t, string(hCopy.Method()), consts.MethodPatch)
+}
+
+func TestResponseHeaderCopyTo(t *testing.T) {
+	t.Parallel()
+
+	h, hCopy := &ResponseHeader{}, &ResponseHeader{}
+	h.SetProtocol(consts.HTTP10)
+	h.SetHeaderLength(100)
+	h.SetNoDefaultContentType(true)
+	h.Add(consts.HeaderContentType, "aaa/bbb")
+	h.Add(consts.HeaderContentEncoding, "gzip")
+	h.Add(consts.HeaderConnection, "close")
+	h.Add(consts.HeaderContentLength, "1234")
+	h.Add(consts.HeaderServer, "aaaa")
+	h.Add(consts.HeaderSetCookie, "cccc")
+	h.Add("aaa", "aaa")
+	h.Add("aaa", "bbb")
+
+	h.CopyTo(hCopy)
+	expectResponseHeaderAll(t, hCopy, consts.HeaderContentType, [][]byte{[]byte("aaa/bbb")})
+	expectResponseHeaderAll(t, hCopy, consts.HeaderContentEncoding, [][]byte{[]byte("gzip")})
+	expectResponseHeaderAll(t, hCopy, consts.HeaderConnection, [][]byte{[]byte("close")})
+	expectResponseHeaderAll(t, hCopy, consts.HeaderContentLength, [][]byte{[]byte("1234")})
+	expectResponseHeaderAll(t, hCopy, consts.HeaderServer, [][]byte{[]byte("aaaa")})
+	expectResponseHeaderAll(t, hCopy, consts.HeaderSetCookie, [][]byte{[]byte("cccc")})
+	expectResponseHeaderAll(t, hCopy, "aaa", [][]byte{[]byte("aaa"), []byte("bbb")})
+	assert.DeepEqual(t, hCopy.GetProtocol(), consts.HTTP10)
+	assert.DeepEqual(t, hCopy.noDefaultContentType, true)
+	assert.DeepEqual(t, hCopy.GetHeaderLength(), 100)
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
修复 `ResponseHeader` 和  `RequestHeader` 的 `CopyTo` 方法没有复制部分字段的问题

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
* In `ResponseHeader.CopyTo`, the `protocol` and `headerLength` fields are not copied
* In `RequestHeader.CopyTo`, the `protocol` field is not copied

zh(optional):
* 在 `ResponseHeader.CopyTo` 中， 没有复制`protocol`和`headerLength`字段
* 在 `RequestHeader.CopyTo` 中， 没有复制`protocol`字段

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
