### PR TITLE
fix: fix error printing of escaped characters in accesslog

### DIFF
--- a/pkg/common/hlog/default.go
+++ b/pkg/common/hlog/default.go
@@ -148,8 +148,10 @@ func (ll *defaultLogger) logf(lv Level, format *string, v ...interface{}) {
 		return
 	}
 	msg := lv.toString()
-	if format != nil {
+	if format != nil && len(v) > 0 {
 		msg += fmt.Sprintf(*format, v...)
+	} else if format != nil && len(v) == 0 {
+		msg += *format
 	} else {
 		msg += fmt.Sprint(v...)
 	}

--- a/pkg/common/hlog/default.go
+++ b/pkg/common/hlog/default.go
@@ -148,13 +148,16 @@ func (ll *defaultLogger) logf(lv Level, format *string, v ...interface{}) {
 		return
 	}
 	msg := lv.toString()
-	if format != nil && len(v) > 0 {
-		msg += fmt.Sprintf(*format, v...)
-	} else if format != nil && len(v) == 0 {
-		msg += *format
+	if format != nil {
+		if len(v) > 0 {
+			msg += fmt.Sprintf(*format, v...)
+		} else {
+			msg += *format
+		}
 	} else {
 		msg += fmt.Sprint(v...)
 	}
+
 	ll.stdlog.Output(ll.depth, msg)
 	if lv == LevelFatal {
 		os.Exit(1)

--- a/pkg/common/hlog/default_test.go
+++ b/pkg/common/hlog/default_test.go
@@ -107,6 +107,16 @@ func TestCtxLogger(t *testing.T) {
 		"[Error] work failed\n", string(w.b))
 }
 
+func TestFormatLoggerWithEscapedCharacters(t *testing.T) {
+	initTestLogger()
+
+	var w byteSliceWriter
+	SetOutput(&w)
+
+	Infof("http://localhost:8080/ping?f=http://localhost:3000/hello?c=%E5%A4%A7hi%E5%93%A6%E5%95%8A%E8%AF%B4%E5%BE%97%E5%A5%BD")
+	assert.DeepEqual(t, "[Info] http://localhost:8080/ping?f=http://localhost:3000/hello?c=%E5%A4%A7hi%E5%93%A6%E5%95%8A%E8%AF%B4%E5%BE%97%E5%A5%BD\n", string(w.b))
+}
+
 func TestSetLevel(t *testing.T) {
 	setLogger := &defaultLogger{
 		stdlog: log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile|log.Lmicroseconds),


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
修复在 accesslog中打印转义字符报错

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
zh: 在 https://github.com/cloudwego/hertz/issues/807 中会出现打印转义字符出错的问题

原因:
在 v 为 nil 时, format 充满了含有 % 的转义字符, 就会出现类似 %!C(MISSING) 的转义字符缺失的问题

解决方案:
增加 v 是否为 nil 的判断, 通过判断使用不同的打印日志的方法
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
https://github.com/cloudwego/hertz/issues/807
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
