### PR TITLE
fix: reset all of the filed when reset body stream

### DIFF
--- a/pkg/protocol/http1/ext/stream.go
+++ b/pkg/protocol/http1/ext/stream.go
@@ -315,11 +315,18 @@ func (rs *bodyStream) skipRest() error {
 func ReleaseBodyStream(requestReader io.Reader) (err error) {
 	if rs, ok := requestReader.(*bodyStream); ok {
 		err = rs.skipRest()
-		rs.prefetchedBytes = nil
-		rs.offset = 0
-		rs.reader = nil
-		rs.trailer = nil
+		rs.reset()
 		bodyStreamPool.Put(rs)
 	}
 	return
+}
+
+func (rs *bodyStream) reset() {
+	rs.prefetchedBytes = nil
+	rs.offset = 0
+	rs.reader = nil
+	rs.trailer = nil
+	rs.chunkEOF = false
+	rs.chunkLeft = 0
+	rs.contentLength = 0
 }

--- a/pkg/protocol/http1/ext/stream_test.go
+++ b/pkg/protocol/http1/ext/stream_test.go
@@ -16,6 +16,7 @@
 package ext
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"testing"
@@ -87,4 +88,27 @@ func TestChunkedSkipRest(t *testing.T) {
 
 	// big body
 	testChunkedSkipRestWithBodySize(t, 3*1024*1024)
+}
+
+func TestBodyStream_Reset(t *testing.T) {
+	t.Parallel()
+	bs := bodyStream{
+		prefetchedBytes: bytes.NewReader([]byte("aaa")),
+		reader:          mock.NewZeroCopyReader("bbb"),
+		trailer:         &protocol.Trailer{},
+		offset:          10,
+		contentLength:   20,
+		chunkLeft:       50,
+		chunkEOF:        true,
+	}
+
+	bs.reset()
+
+	assert.Nil(t, bs.prefetchedBytes)
+	assert.Nil(t, bs.reader)
+	assert.Nil(t, bs.trailer)
+	assert.DeepEqual(t, 0, bs.offset)
+	assert.DeepEqual(t, 0, bs.contentLength)
+	assert.DeepEqual(t, 0, bs.chunkLeft)
+	assert.False(t, bs.chunkEOF)
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
回收的时候重置bodyStream上所有字段

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
en: 
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
