### PR TITLE
test(http1): fix retry test 

### DIFF
--- a/pkg/protocol/http1/client_test.go
+++ b/pkg/protocol/http1/client_test.go
@@ -437,7 +437,7 @@ func TestRetry(t *testing.T) {
 				Delay:           time.Millisecond * 10,
 			},
 			RetryIfFunc: func(req *protocol.Request, resp *protocol.Response, err error) bool {
-				return true
+				return resp.Header.ContentLength() != 10
 			},
 		},
 		Addr: "foobar",


### PR DESCRIPTION
#### What type of PR is this?
test
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
修复 http1 的测试用例
 https://github.com/cloudwego/hertz/actions/runs/5607966832/job/15254925698?pr=863

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
The test case fails due to not following https://github.com/cloudwego/hertz/pull/860 change.
Even if there is a custom retry function before the change, it will not retry when err is nil. After the change, the retry rules will be determined by the retry function, so the test case is wrong.

zh(optional):
测试用例失败，需要跟随 https://github.com/cloudwego/hertz/pull/860 的变更。
在变更前即使有自定义重试函数，但 err 为 nil 时不再重试，变更后重试规则交给重试函数决定，因此测试用例是错误的。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
