### PR TITLE
optimize(client): do not write body in stream mode if content-length is 0

### DIFF
--- a/pkg/common/test/mock/network.go
+++ b/pkg/common/test/mock/network.go
@@ -172,7 +172,11 @@ type BrokenConn struct {
 }
 
 func (o *BrokenConn) Peek(i int) ([]byte, error) {
-	return nil, io.EOF
+	return nil, io.ErrUnexpectedEOF
+}
+
+func (o *BrokenConn) Read(b []byte) (n int, err error) {
+	return 0, io.ErrUnexpectedEOF
 }
 
 func (o *BrokenConn) Flush() error {

--- a/pkg/common/test/mock/network_test.go
+++ b/pkg/common/test/mock/network_test.go
@@ -202,7 +202,7 @@ func TestBrokenConn_Peek(t *testing.T) {
 	conn := NewBrokenConn("Foo")
 	buf, err := conn.Peek(3)
 	assert.Nil(t, buf)
-	assert.DeepEqual(t, io.EOF, err)
+	assert.DeepEqual(t, io.ErrUnexpectedEOF, err)
 }
 
 func TestOneTimeConn_Flush(t *testing.T) {

--- a/pkg/protocol/http1/ext/common.go
+++ b/pkg/protocol/http1/ext/common.go
@@ -135,6 +135,9 @@ func WriteBodyChunked(w network.Writer, r io.Reader) error {
 }
 
 func WriteBodyFixedSize(w network.Writer, r io.Reader, size int64) error {
+	if size == 0 {
+		return nil
+	}
 	if size > consts.MaxSmallFileSize {
 		if err := w.Flush(); err != nil {
 			return err

--- a/pkg/protocol/http1/ext/common_test.go
+++ b/pkg/protocol/http1/ext/common_test.go
@@ -155,6 +155,12 @@ func TestBodyFixedSize(t *testing.T) {
 	assert.DeepEqual(t, body, rb)
 }
 
+func TestBodyFixedSizeQuickPath(t *testing.T) {
+	conn := mock.NewBrokenConn("")
+	err := WriteBodyFixedSize(conn.Writer(), conn, 0)
+	assert.Nil(t, err)
+}
+
 func TestBodyIdentity(t *testing.T) {
 	body := mock.CreateFixedBody(1024)
 	zr := mock.NewZeroCopyReader(string(body))


### PR DESCRIPTION
#### What type of PR is this?
optimize

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
client 写请求body的时候，如果明确content-length为0，则返回

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en:
Under the standard network library, the writing logic with a content-length length of 0 is currently with no special treatment. Although it does not affect the final result, it will enter the [copyBuffer](https://github.com/golang/go/blob/8488309192b0ed4b393e2f7b2a93491139ff8ad0/src/io/io.go#L408) of the standard library logic, execute [buffer initialization logic](https://github.com/golang/go/blob/8488309192b0ed4b393e2f7b2a93491139ff8ad0/src/io/io.go#L418), this will bring unnecessary cpu/mem overhead

zh(optional):
当前未显示处理标准网络库下，对于 content-length 长度为0的写逻辑，导致虽然不影响最终结果，但是会进入标准库的[copyBuffer](https://github.com/golang/go/blob/8488309192b0ed4b393e2f7b2a93491139ff8ad0/src/io/io.go#L408)逻辑，执行[buffer初始化逻辑](https://github.com/golang/go/blob/8488309192b0ed4b393e2f7b2a93491139ff8ad0/src/io/io.go#L418)，这个会带来不必要的cpu/mem开销

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
