### PR TITLE
fix: keep isTLS field in keepalive when reset the request

### DIFF
--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -754,7 +754,8 @@ func (ctx *RequestContext) ResetWithoutConn() {
 		close(ctx.finished)
 		ctx.finished = nil
 	}
-	ctx.Request.Reset()
+
+	ctx.Request.ResetWithoutConn()
 	ctx.Response.Reset()
 	if ctx.IsEnableTrace() {
 		ctx.traceInfo.Reset()

--- a/pkg/app/context_test.go
+++ b/pkg/app/context_test.go
@@ -654,8 +654,10 @@ func TestContextReset(t *testing.T) {
 	c.Params = param.Params{param.Param{}}
 	c.Error(errors.New("test")) // nolint: errcheck
 	c.Set("foo", "bar")
+	c.Request.SetIsTLS(true)
 	c.ResetWithoutConn()
-
+	c.Request.URI()
+	assert.DeepEqual(t, "https", string(c.Request.Scheme()))
 	assert.False(t, c.IsAborted())
 	assert.DeepEqual(t, 0, len(c.Errors))
 	assert.Nil(t, c.Errors.Errors())


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: `<type>(optional scope): <description>`.
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io).

#### (Optional) Translate the PR title into Chinese.
长链接场景重置请求时保留，请求中和连接相关的字段（isTLS）

#### (Optional) More detail description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review. If it is a perf type PR, perf data is suggested to give.
-->
en: 
There is a special filed (isTLS) in the request, which is a link-related field, and its life cycle follows the link. Therefore, in the keepalive scenario, this field needs to be skipped when resetting the request, otherwise it will affect the scheme judgment of the subsequent request of the long link.

zh(optional):
请求里有个特殊filed（isTLS），它是一个链接相关字段，生命周期跟随链接，因此在长链接复用场景，重置请求的时候需要跳过该字段，否则影响长链接后续请求的scheme判断。

#### (Optional) Which issue(s) this PR fixes:
fixes #874 

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
