### PR TITLE
fix: only skip if the next chars are CRLF

### DIFF
--- a/pkg/common/utils/chunk.go
+++ b/pkg/common/utils/chunk.go
@@ -65,9 +65,9 @@ func ParseChunkSize(r network.Reader) (int, error) {
 	return n, nil
 }
 
+// SkipCRLF will only skip the next CRLF("\r\n"), otherwise, error will be returned.
 func SkipCRLF(reader network.Reader) error {
 	p, err := reader.Peek(len(bytestr.StrCRLF))
-	reader.Skip(len(p)) // nolint: errcheck
 	if err != nil {
 		return err
 	}
@@ -75,5 +75,6 @@ func SkipCRLF(reader network.Reader) error {
 		return errBrokenChunk
 	}
 
+	reader.Skip(len(p)) // nolint: errcheck
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
chunk 解析时只有下两个字符为 CRLF，才跳过

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: The skipped buffer is no longer reliable, here the real skip operation is adjusted after all read comparison operations.
zh(optional): 被skip的buffer不再可靠，这里将真正的skip操作调整到所有读取比对操作之后。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->