### PR TITLE
feat: add end chunk for broken reader

### DIFF
--- a/pkg/protocol/http1/ext/common.go
+++ b/pkg/protocol/http1/ext/common.go
@@ -51,6 +51,7 @@ import (
 	"github.com/cloudwego/hertz/internal/bytesconv"
 	"github.com/cloudwego/hertz/internal/bytestr"
 	errs "github.com/cloudwego/hertz/pkg/common/errors"
+	"github.com/cloudwego/hertz/pkg/common/hlog"
 	"github.com/cloudwego/hertz/pkg/common/utils"
 	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/hertz/pkg/protocol"
@@ -117,9 +118,16 @@ func WriteBodyChunked(w network.Writer, r io.Reader) error {
 			if err == nil {
 				panic("BUG: io.Reader returned 0, nil")
 			}
+
+			if !errors.Is(err, io.EOF) {
+				hlog.SystemLogger().Warnf("writing chunked response body encountered an error from the reader, "+
+					"this may cause the short of the content in response body, error: %s", err.Error())
+			}
+
 			if err = WriteChunk(w, buf[:0], true); err != nil {
 				break
 			}
+
 			err = nil
 			break
 		}

--- a/pkg/protocol/http1/ext/common.go
+++ b/pkg/protocol/http1/ext/common.go
@@ -117,12 +117,10 @@ func WriteBodyChunked(w network.Writer, r io.Reader) error {
 			if err == nil {
 				panic("BUG: io.Reader returned 0, nil")
 			}
-			if err == io.EOF {
-				if err = WriteChunk(w, buf[:0], true); err != nil {
-					break
-				}
-				err = nil
+			if err = WriteChunk(w, buf[:0], true); err != nil {
+				break
 			}
+			err = nil
 			break
 		}
 		if err = WriteChunk(w, buf[:n], true); err != nil {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
流式写chunk的时候即使reader损坏，仍然给会写的body加一个last chunk，保证协议完整。


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: 
Before, If the reader returns (0, err), and err is not io.EOF, the streaming chunk writing logic will exit directly, which will cause the response body to return incomplete chunks (lack of last chunk) when such problems occur, which will lead to some agents behave abnormally.

zh(optional): 
在这之前，如果reader返回 (0，err)，err 非 io.EOF，流式写 chunk 逻辑会直接退出，这会导致发生此类问题的时候 response body 回去的chunk并不完整（缺少last chunk），这个会导致一些 agent 行为异常。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->