### PR TITLE
feat: add config hook for host client

### DIFF
--- a/pkg/app/client/client.go
+++ b/pkg/app/client/client.go
@@ -513,6 +513,16 @@ func (c *Client) do(ctx context.Context, req *protocol.Request, resp *protocol.R
 			ProxyURI: proxyURI,
 			IsTLS:    isTLS,
 		})
+
+		// re-configure hook
+		if c.options.HostClientConfigHook != nil {
+			err = c.options.HostClientConfigHook(hc)
+			if err != nil {
+				c.mLock.Unlock()
+				return err
+			}
+		}
+
 		m[h] = hc
 		if len(m) == 1 {
 			startCleaner = true

--- a/pkg/app/client/option.go
+++ b/pkg/app/client/option.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/hertz/pkg/network/dialer"
 	"github.com/cloudwego/hertz/pkg/network/standard"
-	"github.com/cloudwego/hertz/pkg/protocol/client"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
 
@@ -101,7 +100,7 @@ func WithResponseBodyStream(b bool) config.ClientOption {
 }
 
 // WithHostClientConfigHook is used to set the function hook for re-configure the host client.
-func WithHostClientConfigHook(h func(hc client.HostClient) error) config.ClientOption {
+func WithHostClientConfigHook(h func(hc interface{}) error) config.ClientOption {
 	return config.ClientOption{F: func(o *config.ClientOptions) {
 		o.HostClientConfigHook = h
 	}}

--- a/pkg/app/client/option.go
+++ b/pkg/app/client/option.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/hertz/pkg/network/dialer"
 	"github.com/cloudwego/hertz/pkg/network/standard"
+	"github.com/cloudwego/hertz/pkg/protocol/client"
 	"github.com/cloudwego/hertz/pkg/protocol/consts"
 )
 
@@ -96,6 +97,13 @@ func WithDialer(d network.Dialer) config.ClientOption {
 func WithResponseBodyStream(b bool) config.ClientOption {
 	return config.ClientOption{F: func(o *config.ClientOptions) {
 		o.ResponseBodyStream = b
+	}}
+}
+
+// WithHostClientConfigHook is used to set the function hook for re-configure the host client.
+func WithHostClientConfigHook(h func(hc client.HostClient) error) config.ClientOption {
+	return config.ClientOption{F: func(o *config.ClientOptions) {
+		o.HostClientConfigHook = h
 	}}
 }
 

--- a/pkg/common/config/client_option.go
+++ b/pkg/common/config/client_option.go
@@ -128,6 +128,10 @@ type ClientOptions struct {
 
 	// StateObserve execution interval
 	ObservationInterval time.Duration
+
+	// Callback hook for re-configuring host client
+	// If an error is returned, the request will be terminated.
+	HostClientConfigHook func(hc interface{}) error
 }
 
 func NewClientOptions(opts []ClientOption) *ClientOptions {


### PR DESCRIPTION
#### What type of PR is this?
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
给 Host client 增加一个 hook 函数提供灵活配置的能力

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
After the host client is initialized, before the host client takes effect, the user hopes to have the ability to modify the fields on the host client, which can be easily realized through this hook.

zh(optional):
在初始化host client之后，在host client正式生效前，业务存在类似修改host client上字段的能力，通过这个hook可以轻松实现

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->