### PR TITLE
fix: customized type decode for binding

### DIFF
--- a/pkg/app/server/binding/internal/decoder/customized_type_decoder.go
+++ b/pkg/app/server/binding/internal/decoder/customized_type_decoder.go
@@ -69,6 +69,9 @@ func (d *customizedFieldTextDecoder) Decode(req *protocol.Request, params param.
 			break
 		}
 	}
+	if !exist {
+		return nil
+	}
 	if len(text) == 0 && len(defaultValue) != 0 {
 		text = defaultValue
 	}
@@ -76,6 +79,9 @@ func (d *customizedFieldTextDecoder) Decode(req *protocol.Request, params param.
 	v, err := d.decodeFunc(req, params, text)
 	if err != nil {
 		return err
+	}
+	if !v.IsValid() {
+		return nil
 	}
 
 	reqValue = GetFieldValue(reqValue, d.parentIndex)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复自定义绑定函数带来的 time.Time 绑定不一致的行为

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: Fix inconsistent behavior of time.Time bindings due to custom binding functions
zh(optional): 修复自定义绑定函数带来的 time.Time 绑定不一致的行为
之前的绑定行为是必须有对应的 tag 才会去执行，自定义校验函数，例如下方结构体，只有请求的 query 有 "A" 的时候才会去执行自定义绑定函数。
```
type A struct {
     A  time.Time `query:"A"`
}
```
重构后，修改了这一行为，认为 "只要定义了自定义绑定函数就一定会执行，并且会将请求内容传给用户，让其自行取值"，所以自带的 time.Time 的自定义方法会将用户 json 已经解析过的 time.Time 覆盖掉。
这块还是改回只有 tag 存在才执行自定义方法，避免出现其他覆盖的行为

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/cloudwego/hertz/issues/964
#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->