### PR TITLE
fix: param router doesn't match param

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -303,9 +303,7 @@ func (r *router) insert(path string, h app.HandlersChain, t kind, ppath string, 
 			if h != nil {
 				currentNode.handlers = h
 				currentNode.ppath = ppath
-				if len(currentNode.pnames) == 0 {
-					currentNode.pnames = pnames
-				}
+				currentNode.pnames = pnames
 			}
 		}
 		return

--- a/pkg/route/tree_test.go
+++ b/pkg/route/tree_test.go
@@ -706,3 +706,32 @@ func TestTreeFindCaseInsensitivePath(t *testing.T) {
 		}
 	}
 }
+
+func TestTreeParamNotOptimize(t *testing.T) {
+	tree := &router{method: "GET", root: &node{}, hasTsrHandler: make(map[string]bool)}
+	routes := [...]string{
+		"/:parama/start",
+		"/:paramb",
+	}
+	for _, route := range routes {
+		tree.addRoute(route, fakeHandler(route))
+	}
+	checkRequests(t, tree, testRequests{
+		{"/1", false, "/:paramb", param.Params{param.Param{Key: "paramb", Value: "1"}}},
+		{"/1/start", false, "/:parama/start", param.Params{param.Param{Key: "parama", Value: "1"}}},
+	})
+
+	// other sequence
+	tree = &router{method: "GET", root: &node{}, hasTsrHandler: make(map[string]bool)}
+	routes = [...]string{
+		"/:paramb",
+		"/:parama/start",
+	}
+	for _, route := range routes {
+		tree.addRoute(route, fakeHandler(route))
+	}
+	checkRequests(t, tree, testRequests{
+		{"/1/start", false, "/:parama/start", param.Params{param.Param{Key: "parama", Value: "1"}}},
+		{"/1", false, "/:paramb", param.Params{param.Param{Key: "paramb", Value: "1"}}},
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修复参数路由参数不匹配的问题

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: When registering longer parameter routes before shorter ones, the parameters may not match.
zh(optional): 当先注册较长的参数路由，再注册较短的参数路由时，参数可能不匹配

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->