### PR TITLE
WIP:optimize(hz): generate enum marshal and unmarshal separately

### DIFF
--- a/cmd/hz/config/cmd.go
+++ b/cmd/hz/config/cmd.go
@@ -178,8 +178,10 @@ func (arg *Argument) GetThriftgoOptions() (string, error) {
 		return "", err
 	}
 	arg.ThriftOptions = append(arg.ThriftOptions, "package_prefix="+prefix)
+	arg.ThriftOptions = append(arg.ThriftOptions, "enum_unmarshal")
 	if arg.JSONEnumStr {
-		arg.ThriftOptions = append(arg.ThriftOptions, "json_enum_as_text")
+		// todo: 等 thriftgo 发版，设置一个最低版本限制，或者读取 thriftgo 的版本，来设置用 enum_marshal 还是 json_enum_as_text，这两个选项已经在thriftgo做了兼容处理
+		arg.ThriftOptions = append(arg.ThriftOptions, "enum_marshal")
 	}
 	gas := "go:" + strings.Join(arg.ThriftOptions, ",") + ",reserve_comments,gen_json_tag=false"
 	return gas, nil


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
optimize
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
修改 thrift 生成 enum marshal/unmarshal  的行为

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: generate enum marshal and unmarshal separately
zh(optional):
之前的 thriftgo 提供了"json_enum_as_text" 选项，该选项的描述是只生成 enum 的 marshalText 能力；但是实际使用后会将 "marshalText"&"unmarshalText"都生成出来，因此做了一次更细粒度的生成。
行为不一致:

- 之前默认不生成 unmarshal，修改后默认都生成 unmarshal()。这个才是合理的默认行为

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->