### PR TITLE
optimize: prebind without content-length

### DIFF
--- a/pkg/app/server/binding/binder_test.go
+++ b/pkg/app/server/binding/binder_test.go
@@ -1556,3 +1556,31 @@ func Benchmark_Binding(b *testing.B) {
 		}
 	}
 }
+
+// TestBind_BindProtobufWithoutContentLength for issue-983
+func TestBind_BindProtobufWithoutContentLength(t *testing.T) {
+	data := testdata.HertzReq{Name: "hertz"}
+	body, err := proto.Marshal(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := newMockRequest().
+		SetRequestURI("http://foobar.com").
+		SetProtobufContentType().
+		SetBody(body)
+
+	req.Req.Header.Del("Content-Length")
+	result := testdata.HertzReq{}
+	err = DefaultBinder().BindAndValidate(req.Req, &result, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.DeepEqual(t, "hertz", result.Name)
+
+	result = testdata.HertzReq{}
+	err = DefaultBinder().BindProtobuf(req.Req, &result)
+	if err != nil {
+		t.Error(err)
+	}
+	assert.DeepEqual(t, "hertz", result.Name)
+}

--- a/pkg/app/server/binding/default.go
+++ b/pkg/app/server/binding/default.go
@@ -319,7 +319,7 @@ func (b *defaultBinder) Bind(req *protocol.Request, v interface{}, params param.
 
 // best effort binding
 func (b *defaultBinder) preBindBody(req *protocol.Request, v interface{}) error {
-	if req.Header.ContentLength() <= 0 {
+	if len(req.Body()) == 0 {
 		return nil
 	}
 	ct := bytesconv.B2s(req.Header.ContentType())


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
optimize
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
优化 prebind 的判断条件

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:optimize prebind without content-length
zh(optional): 优化 prebind 的判断条件
一些场景下会将 content-length 置为0，导致 prebind 在进行预绑定的时候只根据 content-length 判断会漏掉一些 body

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
https://github.com/cloudwego/hertz/issues/983
#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->