### PR TITLE
feat: add WithDisableDefaultDate, WithDisableDefaultContentType for server config options

### DIFF
--- a/pkg/app/server/hertz_test.go
+++ b/pkg/app/server/hertz_test.go
@@ -1066,3 +1066,29 @@ func TestValidateConfigAndBindConfig(t *testing.T) {
 	assert.Nil(t, err)
 	time.Sleep(100 * time.Millisecond)
 }
+
+func TestWithDisableDefaultDate(t *testing.T) {
+	h := New(
+		WithHostPorts("localhost:8321"),
+		WithDisableDefaultDate(true),
+	)
+	h.GET("/", func(_ context.Context, c *app.RequestContext) {})
+	go h.Spin()
+	time.Sleep(100 * time.Millisecond)
+	hc := http.Client{Timeout: time.Second}
+	r, _ := hc.Get("http://127.0.0.1:8321") //nolint:errcheck
+	assert.DeepEqual(t, "", r.Header.Get("Date"))
+}
+
+func TestWithDisableDefaultContentType(t *testing.T) {
+	h := New(
+		WithHostPorts("localhost:8324"),
+		WithDisableDefaultContentType(true),
+	)
+	h.GET("/", func(_ context.Context, c *app.RequestContext) {})
+	go h.Spin()
+	time.Sleep(100 * time.Millisecond)
+	hc := http.Client{Timeout: time.Second}
+	r, _ := hc.Get("http://127.0.0.1:8324") //nolint:errcheck
+	assert.DeepEqual(t, "", r.Header.Get("Content-Type"))
+}

--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -382,3 +382,15 @@ func WithDisableHeaderNamesNormalizing(disable bool) config.Option {
 		o.DisableHeaderNamesNormalizing = disable
 	}}
 }
+
+func WithDisableDefaultDate(disable bool) config.Option {
+	return config.Option{F: func(o *config.Options) {
+		o.NoDefaultDate = disable
+	}}
+}
+
+func WithDisableDefaultContentType(disable bool) config.Option {
+	return config.Option{F: func(o *config.Options) {
+		o.NoDefaultContentType = disable
+	}}
+}

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -58,6 +58,8 @@ type Options struct {
 	RemoveExtraSlash             bool
 	UnescapePathValues           bool
 	DisablePreParseMultipartForm bool
+	NoDefaultDate                bool
+	NoDefaultContentType         bool
 	StreamRequestBody            bool
 	NoDefaultServerHeader        bool
 	DisablePrintRoute            bool
@@ -190,6 +192,12 @@ func NewOptions(opts []Option) *Options {
 		// The default is to automatically read request bodies of Expect 100 Continue requests
 		// like they are normal requests
 		DisablePreParseMultipartForm: false,
+
+		// When set to true, causes the default Content-Type header to be excluded from the response.
+		NoDefaultContentType: false,
+
+		// When set to true, causes the default date header to be excluded from the response.
+		NoDefaultDate: false,
 
 		// Routes info printing is not disabled by default
 		// Disabled when set to True

--- a/pkg/protocol/header.go
+++ b/pkg/protocol/header.go
@@ -950,6 +950,11 @@ func (h *ResponseHeader) SetNoDefaultContentType(b bool) {
 	h.noDefaultContentType = b
 }
 
+// SetNoDefaultDate set noDefaultDate value of ResponseHeader.
+func (h *ResponseHeader) SetNoDefaultDate(b bool) {
+	h.noDefaultDate = b
+}
+
 // SetServerBytes sets Server header value.
 func (h *ResponseHeader) SetServerBytes(server []byte) {
 	h.server = append(h.server[:0], server...)

--- a/pkg/protocol/header_test.go
+++ b/pkg/protocol/header_test.go
@@ -720,3 +720,18 @@ func TestResponseHeaderCopyTo(t *testing.T) {
 	assert.DeepEqual(t, hCopy.noDefaultContentType, true)
 	assert.DeepEqual(t, hCopy.GetHeaderLength(), 100)
 }
+
+func TestResponseDateNoDefaultNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	var h ResponseHeader
+	h.noDefaultDate = true
+	headers := string(h.Header())
+
+	if strings.Contains(headers, "\r\nDate: ") {
+		t.Fatalf("ResponseDateNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", h, headers) //nolint:govet
+	}
+}
+
+func TestResponseDateNoDefaultEmpty(t *testing.T) {
+}

--- a/pkg/protocol/header_test.go
+++ b/pkg/protocol/header_test.go
@@ -721,7 +721,7 @@ func TestResponseHeaderCopyTo(t *testing.T) {
 	assert.DeepEqual(t, hCopy.GetHeaderLength(), 100)
 }
 
-func TestResponseDateNoDefaultNotEmpty(t *testing.T) {
+func TestResponseHeaderDateEmpty(t *testing.T) {
 	t.Parallel()
 
 	var h ResponseHeader
@@ -731,7 +731,4 @@ func TestResponseDateNoDefaultNotEmpty(t *testing.T) {
 	if strings.Contains(headers, "\r\nDate: ") {
 		t.Fatalf("ResponseDateNoDefaultNotEmpty fail, response: \n%+v\noutcome: \n%q\n", h, headers) //nolint:govet
 	}
-}
-
-func TestResponseDateNoDefaultEmpty(t *testing.T) {
 }

--- a/pkg/protocol/http1/server.go
+++ b/pkg/protocol/http1/server.go
@@ -56,6 +56,8 @@ var (
 type Option struct {
 	StreamRequestBody             bool
 	GetOnly                       bool
+	NoDefaultDate                 bool
+	NoDefaultContentType          bool
 	DisablePreParseMultipartForm  bool
 	DisableKeepalive              bool
 	NoDefaultServerHeader         bool
@@ -180,6 +182,9 @@ func (s Server) Serve(c context.Context, conn network.Conn) (err error) {
 				internalStats.Record(ti, stats.ReadHeaderFinish, err)
 			})
 		}
+
+		ctx.Response.Header.SetNoDefaultDate(s.NoDefaultDate)
+		ctx.Response.Header.SetNoDefaultContentType(s.NoDefaultContentType)
 
 		if s.DisableHeaderNamesNormalizing {
 			ctx.Request.Header.DisableNormalizing()

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -1065,6 +1065,8 @@ func newHttp1OptionFromEngine(engine *Engine) *http1.Option {
 		EnableTrace:                   engine.IsTraceEnable(),
 		HijackConnHandle:              engine.HijackConnHandle,
 		DisableHeaderNamesNormalizing: engine.options.DisableHeaderNamesNormalizing,
+		NoDefaultDate:                 engine.options.NoDefaultDate,
+		NoDefaultContentType:          engine.options.NoDefaultContentType,
 	}
 	// Idle timeout of standard network must not be zero. Set it to -1 seconds if it is zero.
 	// Due to the different triggering ways of the network library, see the actual use of this value for the detailed reasons.


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 给 hertz 添加禁止响应头添加 date 字段和 content-type 字段的选项，主要用于对齐 fasthttp 和 fiber

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->