### PR TITLE
perf: revert NewChunkedBodyWriter

### DIFF
--- a/pkg/protocol/http1/resp/writer.go
+++ b/pkg/protocol/http1/resp/writer.go
@@ -59,6 +59,14 @@ func (c *chunkedBodyWriter) Flush() error {
 // Warning: do not call this method by yourself, unless you know what you are doing.
 func (c *chunkedBodyWriter) Finalize() error {
 	c.Do(func() {
+		// in case no actual data from user
+		if !c.wroteHeader {
+			c.r.Header.SetContentLength(-1)
+			if c.finalizeErr = WriteHeader(&c.r.Header, c.w); c.finalizeErr != nil {
+				return
+			}
+			c.wroteHeader = true
+		}
 		c.finalizeErr = ext.WriteChunk(c.w, nil, true)
 		if c.finalizeErr != nil {
 			return
@@ -70,7 +78,8 @@ func (c *chunkedBodyWriter) Finalize() error {
 
 func NewChunkedBodyWriter(r *protocol.Response, w network.Writer) network.ExtWriter {
 	return &chunkedBodyWriter{
-		r: r,
-		w: w,
+		r:    r,
+		w:    w,
+		Once: sync.Once{},
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 取消池化 NewChunkedBodyWriter

### cpu 时间出现较大差异
![image](https://github.com/cloudwego/hertz/assets/70408571/0fba506c-4062-4eae-9131-d2344abb70e0)
![image](https://github.com/cloudwego/hertz/assets/70408571/3eea0d44-f74a-434e-b85b-72c5b31e3864)
0.7.1 和 0.6.1 版本的 hertz 进行比较, cpu 时间相差 8 倍

### 性能出现劣化

```plaintext
=======================================================
 hertz 0.6.1
=======================================================
Running 1m test @ http://localhost:3000/sse
  8 threads and 512 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    23.68ms   17.15ms 307.82ms   83.41%
    Req/Sec     1.86k     1.01k    4.68k    60.13%
  Latency Distribution
     50%   19.53ms
     75%   28.76ms
     90%   42.53ms
     99%   88.00ms
  776720 requests in 1.00m, 705.20MB read
  Socket errors: connect 212, read 0, write 0, timeout 0
Requests/sec:  12923.79
Transfer/sec:     11.73MB

=======================================================
 hertz 0.7.1
=======================================================

Running 1m test @ http://localhost:3000/sse
  8 threads and 512 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    29.03ms   21.50ms 312.42ms   79.90%
    Req/Sec     1.76k   816.53     4.57k    65.35%
  Latency Distribution
     50%   23.47ms
     75%   37.21ms
     90%   55.44ms
     99%  109.00ms
  630186 requests in 1.00m, 572.16MB read
  Socket errors: connect 212, read 0, write 0, timeout 0
Requests/sec:  10488.32
Transfer/sec:      9.52MB

```
从上面的 wrk 压测结果看出, 0.7.1 版本的 hertz 的各项指标均出现劣化

### runtime.SetFinalizer 使用的并不恰当
添加 runtime.SetFinalizer 的原意是用于兜底回收, 但实际上带来了性能劣化

https://lemire.me/blog/2023/05/19/the-absurd-cost-of-finalizers-in-go/ 

在上面的博客中谈到, 使用 finalizer 会显著增加对象的创建和销毁的时间，大约是不使用 finalizer 的 430 倍。他建议避免使用 finalizer，除非有非常强烈的理由

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->