### PR TITLE
fix: unit tests fail in windows

### DIFF
--- a/pkg/protocol/uri.go
+++ b/pkg/protocol/uri.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cloudwego/hertz/internal/bytesconv"
 	"github.com/cloudwego/hertz/internal/bytestr"
 	"github.com/cloudwego/hertz/internal/nocopy"
-	"github.com/cloudwego/hertz/pkg/common/hlog"
 )
 
 // AcquireURI returns an empty URI instance from the pool.
@@ -388,11 +387,7 @@ func getScheme(rawURL []byte) (scheme, path []byte) {
 				return nil, rawURL
 			}
 		case c == ':':
-			if i == 0 {
-				hlog.Errorf("error happened when try to parse the rawURL(%s): missing protocol scheme", rawURL)
-				return nil, nil
-			}
-			return rawURL[:i], rawURL[i+1:]
+			return checkSchemeWhenCharIsColon(i, rawURL)
 		default:
 			// we have encountered an invalid character,
 			// so there is no valid scheme

--- a/pkg/protocol/uri_unix.go
+++ b/pkg/protocol/uri_unix.go
@@ -44,6 +44,8 @@
 
 package protocol
 
+import "github.com/cloudwego/hertz/pkg/common/hlog"
+
 func addLeadingSlash(dst, src []byte) []byte {
 	// add leading slash for unix paths
 	if len(src) == 0 || src[0] != '/' {
@@ -51,4 +53,14 @@ func addLeadingSlash(dst, src []byte) []byte {
 	}
 
 	return dst
+}
+
+// checkSchemeWhenCharIsColon check url begin with :
+// Scenarios that handle protocols like "http:"
+func checkSchemeWhenCharIsColon(i int, rawURL []byte) (scheme, path []byte) {
+	if i == 0 {
+		hlog.Errorf("error happened when try to parse the rawURL(%s): missing protocol scheme", rawURL)
+		return
+	}
+	return rawURL[:i], rawURL[i+1:]
 }

--- a/pkg/protocol/uri_unix_test.go
+++ b/pkg/protocol/uri_unix_test.go
@@ -1,0 +1,44 @@
+//go:build !windows
+// +build !windows
+
+/*
+ * Copyright 2023 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package protocol
+
+import (
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+)
+
+func TestGetScheme(t *testing.T) {
+	scheme, path := getScheme([]byte("https://foo.com"))
+	assert.DeepEqual(t, "https", string(scheme))
+	assert.DeepEqual(t, "//foo.com", string(path))
+
+	scheme, path = getScheme([]byte(":"))
+	assert.DeepEqual(t, "", string(scheme))
+	assert.DeepEqual(t, "", string(path))
+
+	scheme, path = getScheme([]byte("ws://127.0.0.1"))
+	assert.DeepEqual(t, "ws", string(scheme))
+	assert.DeepEqual(t, "//127.0.0.1", string(path))
+
+	scheme, path = getScheme([]byte("/hertz/demo"))
+	assert.DeepEqual(t, "", string(scheme))
+	assert.DeepEqual(t, "/hertz/demo", string(path))
+}

--- a/pkg/protocol/uri_windows.go
+++ b/pkg/protocol/uri_windows.go
@@ -44,6 +44,8 @@
 
 package protocol
 
+import "github.com/cloudwego/hertz/pkg/common/hlog"
+
 func addLeadingSlash(dst, src []byte) []byte {
 	// zero length and "C:/" case
 	isDisk := len(src) > 2 && src[1] == ':'
@@ -52,4 +54,21 @@ func addLeadingSlash(dst, src []byte) []byte {
 	}
 
 	return dst
+}
+
+// checkSchemeWhenCharIsColon check url begin with :
+// Scenarios that handle protocols like "http:"
+// Add the path to the win file, e.g. "E:\gopath", "E:\".
+func checkSchemeWhenCharIsColon(i int, rawURL []byte) (scheme, path []byte) {
+	if i == 0 {
+		hlog.Errorf("error happened when trying to parse the rawURL(%s): missing protocol scheme", rawURL)
+		return
+	}
+
+	// case :\
+	if rawURL[i+1] == 92 {
+		return nil, rawURL
+	}
+
+	return rawURL[:i], rawURL[i+1:]
 }

--- a/pkg/protocol/uri_windows.go
+++ b/pkg/protocol/uri_windows.go
@@ -66,8 +66,8 @@ func checkSchemeWhenCharIsColon(i int, rawURL []byte) (scheme, path []byte) {
 	}
 
 	// case :\
-	if rawURL[i+1] == 92 {
-		return nil, rawURL
+	if i+1 < len(rawURL) && rawURL[i+1] == '\\' {
+		return nil, rawURL    
 	}
 
 	return rawURL[:i], rawURL[i+1:]

--- a/pkg/protocol/uri_windows_test.go
+++ b/pkg/protocol/uri_windows_test.go
@@ -14,7 +14,11 @@
 
 package protocol
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+)
 
 func TestURIPathNormalizeIssue86(t *testing.T) {
 	t.Parallel()
@@ -25,4 +29,26 @@ func TestURIPathNormalizeIssue86(t *testing.T) {
 	testURIPathNormalize(t, &u, "/../../../../../foo", "/foo")
 	testURIPathNormalize(t, &u, "/..\\..\\..\\..\\..\\", "/")
 	testURIPathNormalize(t, &u, "/..%5c..%5cfoo", "/foo")
+}
+
+func TestGetScheme(t *testing.T) {
+	scheme, path := getScheme([]byte("E:\\file.go"))
+	assert.DeepEqual(t, "", string(scheme))
+	assert.DeepEqual(t, "E:\\file.go", string(path))
+
+	scheme, path = getScheme([]byte("E:\\"))
+	assert.DeepEqual(t, "", string(scheme))
+	assert.DeepEqual(t, "E:\\", string(path))
+
+	scheme, path = getScheme([]byte("https://foo.com"))
+	assert.DeepEqual(t, "https", string(scheme))
+	assert.DeepEqual(t, "//foo.com", string(path))
+
+	scheme, path = getScheme([]byte("://"))
+	assert.DeepEqual(t, "", string(scheme))
+	assert.DeepEqual(t, "", string(path))
+
+	scheme, path = getScheme([]byte("ws://127.0.0.1"))
+	assert.DeepEqual(t, "ws", string(scheme))
+	assert.DeepEqual(t, "//127.0.0.1", string(path))
 }


### PR DESCRIPTION
#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional): 修复单元测试在 Windows 环境下失败的问题

在 windows 环境下, 文件路径一般形为 E:/gopath/f.go, 不为 unix 的 /gopath/f.go 
该函数并没有考虑到 windows 的这种情况

```go
// Maybe rawURL is of the form scheme:path.
// (Scheme must be [a-zA-Z][a-zA-Z0-9+-.]*)
// If so, return scheme, path; else return nil, rawURL.
func getScheme(rawURL []byte) (scheme, path []byte) {
	for i := 0; i < len(rawURL); i++ {
		c := rawURL[i]
		switch {
		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z':
		// do nothing
		case '0' <= c && c <= '9' || c == '+' || c == '-' || c == '.':
			if i == 0 {
				return nil, rawURL
			}
		case c == ':':
			if i == 0 {
				hlog.Errorf("error happened when try to parse the rawURL(%s): missing protocol scheme", rawURL)
				return nil, nil
			}
			return rawURL[:i], rawURL[i+1:]
		default:
			// we have encountered an invalid character,
			// so there is no valid scheme
			return nil, rawURL
		}
	}
	return nil, rawURL
}


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->