### PR TITLE
fix(hz): use regexp to check if there are duplicate register func in router

### DIFF
--- a/cmd/hz/generator/router.go
+++ b/cmd/hz/generator/router.go
@@ -321,7 +321,10 @@ func (pkgGen *HttpPackageGenerator) updateRegister(pkg, rDir, pkgName string) er
 		}
 
 		insertReg := register.DepPkgAlias + ".Register(r)\n"
-		if bytes.Contains(file, []byte(insertReg)) {
+
+		registerPattern := `(?m)^\s*` + register.DepPkgAlias + `\s*\.\s*Register\(r\)\s*$`
+		re := regexp.MustCompile(registerPattern)
+		if re.Match(file) {
 			return fmt.Errorf("the router(%s) has been registered", insertReg)
 		}
 


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

使用正则表达式来判断 router/register.go 中是否存在同名的注册函数（xxx.register(r)）


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:

When there are two namespaces with the same ending, such as `namespace go a.b` and `namespace b`, hz will import two packages in the `register.go` of the router, which are `a_b` and `b`.

At this time, hz also needs to add `a_b.register(r)` and `b.register(r)` in the register function.

Due to the current version's judgment based on text matching, when `a_b.register(r)` has been added, `b.register(r)` will be judged as an existing function with the same name and throw an error.

The purpose of this PR is to use regxp instead of current text matching to find whether there are duplicate registration functions in `register.go`, in order to solve this problem.


zh(optional):

当出现两个同结尾的命名空间，例如`namespace go a.b`和`namespace b`时，hz 会在 router 的 `register.go`中引入两个包，分别是 `a_b`和`b`。

此时 hz 还需要在register 函数中加入`a_b.register(r)`和`b.register(r)`

由于当前版本判定是根据文本匹配，导致当已加入`a_b.register(r)`时，`b.register(r)`会被判定为已经存在同名函数而抛出错误。

这个 pr 的目的是使用正则表达式替代当前的文本匹配在 `register.go` 中查找是否存在同名的注册函数，以解决这个问题。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://github.com/cloudwego/hertz/issues/1028

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->