### PR TITLE
feat: add SetHandlers when fast fail for no valid host and invalid rPath

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -726,6 +726,7 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 
 	// align with https://datatracker.ietf.org/doc/html/rfc2616#section-5.2
 	if len(ctx.Request.Host()) == 0 && ctx.Request.Header.IsHTTP11() && bytesconv.B2s(ctx.Request.Method()) != consts.MethodConnect {
+		ctx.SetHandlers(engine.Handlers)
 		serveError(c, ctx, consts.StatusBadRequest, requiredHostBody)
 		return
 	}
@@ -743,6 +744,7 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 
 	// Follow RFC7230#section-5.3
 	if rPath == "" || rPath[0] != '/' {
+		ctx.SetHandlers(engine.Handlers)
 		serveError(c, ctx, consts.StatusBadRequest, default400Body)
 		return
 	}


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
当请求缺少Host短路时或者非法path时设置全局中间件

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: As mentioned in https://github.com/cloudwego/hertz/issues/1034, when the request lacks a Host  or a invalid path, the serveError is directly called to return the result, lead to the global middlewares not being executed (accesslog middleware is does not work), so I think the global middlewares should be executed like 404 and 405 scenario.
This is my first time submitting a PR for an open source project. Thank you for your criticism and correction :)

zh(optional): 就像 https://github.com/cloudwego/hertz/issues/1034 提到的那样，当请求缺少Host 或者非法path 请求而短路时时，直接调用serveError返回结果，导致全局中间件没有被执行（accesslog middleware 就不起作用），我认为应该像 404 和 405 错误那样，都应该执行一遍全局中间件;
第一次给开源项目提pr 欢迎大家批评指正  :)

#### (Optional) Which issue(s) this PR fixes:
Fixes #1034 
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->