### PR TITLE
fix: hertz panic when edit ctx.Params on HandleFunc

### DIFF
--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -203,12 +203,11 @@ type RequestContext struct {
 	// Errors is a list of errors attached to all the handlers/middlewares who used this context.
 	Errors errors.ErrorChain
 
-	Params      param.Params
-	paramsCount int
-	handlers    HandlersChain
-	fullPath    string
-	index       int8
-	HTMLRender  render.HTMLRender
+	Params     param.Params
+	handlers   HandlersChain
+	fullPath   string
+	index      int8
+	HTMLRender render.HTMLRender
 
 	// This mutex protect Keys map.
 	mu sync.RWMutex
@@ -299,7 +298,7 @@ func (ctx *RequestContext) SetEnableTrace(enable bool) {
 // Set the Request filed before use it for handlers
 func NewContext(maxParams uint16) *RequestContext {
 	v := make(param.Params, 0, maxParams)
-	ctx := &RequestContext{Params: v, index: -1, paramsCount: int(maxParams)}
+	ctx := &RequestContext{Params: v, index: -1}
 	return ctx
 }
 
@@ -844,10 +843,6 @@ func (ctx *RequestContext) SetHandlers(hc HandlersChain) {
 // For example if the handler is "handleGetUsers()", this function will return "main.handleGetUsers".
 func (ctx *RequestContext) HandlerName() string {
 	return utils.NameOfFunction(ctx.handlers.Last())
-}
-
-func (ctx *RequestContext) GetParamsCount() int {
-	return ctx.paramsCount
 }
 
 func (ctx *RequestContext) ResetWithoutConn() {

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -204,7 +204,7 @@ type RequestContext struct {
 	Errors errors.ErrorChain
 
 	Params      param.Params
-	paramsCount uint16
+	paramsCount int
 	handlers    HandlersChain
 	fullPath    string
 	index       int8
@@ -299,7 +299,7 @@ func (ctx *RequestContext) SetEnableTrace(enable bool) {
 // Set the Request filed before use it for handlers
 func NewContext(maxParams uint16) *RequestContext {
 	v := make(param.Params, 0, maxParams)
-	ctx := &RequestContext{Params: v, index: -1, paramsCount: maxParams}
+	ctx := &RequestContext{Params: v, index: -1, paramsCount: int(maxParams)}
 	return ctx
 }
 
@@ -848,7 +848,7 @@ func (ctx *RequestContext) HandlerName() string {
 
 func (ctx *RequestContext) ResetWithoutConn() {
 	// if ctx.Params is re-assigned by user in HandlerFunc and the capacity changed we need to realloc
-	if cap(ctx.Params) != int(ctx.paramsCount) {
+	if cap(ctx.Params) < ctx.paramsCount {
 		ctx.Params = make(param.Params, ctx.paramsCount)
 	}
 	ctx.Params = ctx.Params[0:0]

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -819,7 +819,9 @@ func (ctx *RequestContext) Copy() *RequestContext {
 func (ctx *RequestContext) Next(c context.Context) {
 	ctx.index++
 	for ctx.index < int8(len(ctx.handlers)) {
+		tempParams := ctx.Params
 		ctx.handlers[ctx.index](c, ctx)
+		ctx.Params = tempParams
 		ctx.index++
 	}
 }

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -846,11 +846,11 @@ func (ctx *RequestContext) HandlerName() string {
 	return utils.NameOfFunction(ctx.handlers.Last())
 }
 
+func (ctx *RequestContext) GetParamsCount() int {
+	return ctx.paramsCount
+}
+
 func (ctx *RequestContext) ResetWithoutConn() {
-	// if ctx.Params is re-assigned by user in HandlerFunc and the capacity changed we need to realloc
-	if cap(ctx.Params) < ctx.paramsCount {
-		ctx.Params = make(param.Params, ctx.paramsCount)
-	}
 	ctx.Params = ctx.Params[0:0]
 	ctx.Errors = ctx.Errors[0:0]
 	ctx.handlers = nil

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -751,8 +751,9 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 	}
 
 	// if ctx.Params is re-assigned by user in HandlerFunc and the capacity changed we need to realloc
-	if cap(ctx.Params) < ctx.GetParamsCount() {
-		ctx.Params = make(param.Params, ctx.GetParamsCount())
+	paramsCnt := int(engine.maxParams)
+	if cap(ctx.Params) < paramsCnt {
+		ctx.Params = make(param.Params, paramsCnt)
 	}
 
 	// Find root of the tree for the given HTTP method

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -750,10 +750,10 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 		return
 	}
 
-	// if ctx.Params is re-assigned by user in HandlerFunc and the capacity changed we need to realloc
-	paramsCnt := int(engine.maxParams)
-	if cap(ctx.Params) < paramsCnt {
-		ctx.Params = make(param.Params, 0, paramsCnt)
+	// if Params is re-assigned in HandlerFunc and the capacity is not enough we need to realloc
+	maxParams := int(engine.maxParams)
+	if cap(ctx.Params) < maxParams {
+		ctx.Params = make(param.Params, 0, maxParams)
 	}
 
 	// Find root of the tree for the given HTTP method

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -753,7 +753,7 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 	// if ctx.Params is re-assigned by user in HandlerFunc and the capacity changed we need to realloc
 	paramsCnt := int(engine.maxParams)
 	if cap(ctx.Params) < paramsCnt {
-		ctx.Params = make(param.Params, paramsCnt)
+		ctx.Params = make(param.Params, 0, paramsCnt)
 	}
 
 	// Find root of the tree for the given HTTP method

--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -75,6 +75,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/protocol/http1"
 	"github.com/cloudwego/hertz/pkg/protocol/http1/factory"
 	"github.com/cloudwego/hertz/pkg/protocol/suite"
+	"github.com/cloudwego/hertz/pkg/route/param"
 )
 
 const unknownTransporterName = "unknown"
@@ -747,6 +748,11 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 		ctx.SetHandlers(engine.Handlers)
 		serveError(c, ctx, consts.StatusBadRequest, default400Body)
 		return
+	}
+
+	// if ctx.Params is re-assigned by user in HandlerFunc and the capacity changed we need to realloc
+	if cap(ctx.Params) < ctx.GetParamsCount() {
+		ctx.Params = make(param.Params, ctx.GetParamsCount())
 	}
 
 	// Find root of the tree for the given HTTP method

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -1032,7 +1032,6 @@ func TestAcquireHijackConn(t *testing.T) {
 
 func TestHandleParamsReassignInHandleFunc(t *testing.T) {
 	e := NewEngine(config.NewOptions(nil))
-	ctx := app.NewContext(3)
 	routes := []string{
 		"/:a/:b/:c",
 	}
@@ -1052,6 +1051,7 @@ func TestHandleParamsReassignInHandleFunc(t *testing.T) {
 		"/alksjdlakjd/ooo/askda",
 		"/alksjdlakjd/ooo/askda",
 	}
+	ctx := e.ctxPool.Get().(*app.RequestContext)
 	for _, tr := range testRoutes {
 		r := protocol.NewRequest(http.MethodGet, tr, nil)
 		r.CopyTo(&ctx.Request)

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -1029,3 +1029,33 @@ func TestAcquireHijackConn(t *testing.T) {
 	assert.DeepEqual(t, engine, hijackConn.e)
 	assert.DeepEqual(t, conn, hijackConn.Conn)
 }
+
+func TestHandleParamsReassignInHandleFunc(t *testing.T) {
+	e := NewEngine(config.NewOptions(nil))
+	ctx := app.NewContext(3)
+	routes := []string{
+		"/:a/:b/:c",
+	}
+	for _, r := range routes {
+		e.GET(r, func(c context.Context, ctx *app.RequestContext) {
+			ctx.Params = make([]param.Param, 1)
+			ctx.String(consts.StatusOK, "")
+		})
+	}
+	testRoutes := []string{
+		"/aaa/bbb/ccc",
+		"/asd/alskja/alkdjad",
+		"/asd/alskja/alkdjad",
+		"/asd/alskja/alkdjad",
+		"/asd/alskja/alkdjad",
+		"/alksjdlakjd/ooo/askda",
+		"/alksjdlakjd/ooo/askda",
+		"/alksjdlakjd/ooo/askda",
+	}
+	for _, tr := range testRoutes {
+		r := protocol.NewRequest(http.MethodGet, tr, nil)
+		r.CopyTo(&ctx.Request)
+		e.ServeHTTP(context.Background(), ctx)
+		ctx.ResetWithoutConn()
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

修复因用户在 HandleFunc 中修改 ctx.Params 值导致的 panic

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: This panic is happening because `RequestContext.ResetWithoutConn` only reset the length of Params (slice), not the array itself. Therefore, if the Params is re-assigned to another array by the user, it is possible that the capacity is not enough, leading to an out of bound array index. To fix this, we need to compare the current capacity and the expected capacity in `RequestContext.ResetWithoutConn`, and if they do not match, realloc Params.
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #1149 

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->