### PR TITLE
feat: add `PostFormMap` and `GetPostFormMap` to `RequestContext`

### DIFF
--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -1399,7 +1399,7 @@ func (ctx *RequestContext) PostForm(key string) string {
 	return value
 }
 
-// PostFormArray returns the specified key from a POST urlencoded form or multipart form
+// PostFormArray returns an array of the specified key from a POST urlencoded form or multipart form
 // when it exists, otherwise it returns an empty array `([])`.
 func (ctx *RequestContext) PostFormArray(key string) []string {
 	values, _ := ctx.GetPostFormArray(key)
@@ -1446,9 +1446,9 @@ func (ctx *RequestContext) GetPostForm(key string) (string, bool) {
 //
 // For example, during a PATCH request to update the item's tags:
 //
-//	    tag=tag1 tag=tag2 tag=tag3  -->  (["tag1", "tag2", "tag3"], true) := GetPostFormArray("tags") // set tags to ["tag1", "tag2", "tag3"]
-//		   tags=                  -->  (nil, true) := GetPostFormArray("tags") // set tags to nil
-//	                            -->  (nil, false) := GetPostFormArray("tags") // do nothing with tags
+//	    tag=tag1 tag=tag2 tag=tag3  -->  (["tag1", "tag2", "tag3"], true) := GetPostFormArray("tag") // set tag to ["tag1", "tag2", "tag3"]
+//		   tag=                  -->  (nil, true) := GetPostFormArray("tag") // set tags to nil
+//	                            -->  (nil, false) := GetPostFormArray("tag") // do nothing with tags
 func (ctx *RequestContext) GetPostFormArray(key string) ([]string, bool) {
 	vs := ctx.PostArgs().PeekAll(key)
 	values := make([]string, len(vs))

--- a/pkg/app/context_test.go
+++ b/pkg/app/context_test.go
@@ -401,6 +401,38 @@ tag=red&tag=green&tag=blue
 	assert.DeepEqual(t, []string{"red", "green", "blue"}, ctx.PostFormArray("tag"))
 }
 
+func TestPostFormMap(t *testing.T) {
+	ctx := makeCtxByReqString(t, `POST /upload HTTP/1.1
+Host: localhost:10000
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryJwfATyF8tmxSJnLg
+Content-Length: 521
+
+------WebKitFormBoundaryJwfATyF8tmxSJnLg
+Content-Disposition: form-data; name="object[name]"
+
+liteyuki
+------WebKitFormBoundaryJwfATyF8tmxSJnLg
+Content-Disposition: form-data; name="object[id]"
+
+200216
+------WebKitFormBoundaryJwfATyF8tmxSJnLg
+Content-Disposition: form-data; name="object[age]"
+
+18
+------WebKitFormBoundaryJwfATyF8tmxSJnLg--
+`)
+	assert.DeepEqual(t, map[string]string{"name": "liteyuki", "id": "200216", "age": "18"}, ctx.PostFormMap("object"))
+
+	ctx = makeCtxByReqString(t, `POST /upload HTTP/1.1
+Host: localhost:10000
+Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+Content-Length: 54
+
+object[name]=liteyuki&object[id]=200216&object[age]=18
+`)
+	assert.DeepEqual(t, map[string]string{"name": "liteyuki", "id": "200216", "age": "18"}, ctx.PostFormMap("object"))
+}
+
 func TestDefaultPostForm(t *testing.T) {
 	ctx := makeCtxByReqString(t, `POST /upload HTTP/1.1
 Host: localhost:10000
@@ -974,6 +1006,14 @@ func TestGetPostFormArray(t *testing.T) {
 	c.Request.SetBodyString("a=1&b=2&b=3")
 	v, _ := c.GetPostFormArray("b")
 	assert.DeepEqual(t, []string{"2", "3"}, v)
+}
+
+func TestGetPostFormMap(t *testing.T) {
+	c := NewContext(0)
+	c.Request.Header.SetContentTypeBytes([]byte(consts.MIMEApplicationHTMLForm))
+	c.Request.SetBodyString("attr[name]=lts&attr[id]=114514&attr[age]=24&key=1919810")
+	v, _ := c.GetPostFormMap("attr")
+	assert.DeepEqual(t, map[string]string{"name": "lts", "id": "114514", "age": "24"}, v)
 }
 
 func TestRemoteAddr(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
feat
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
为`RequestContext`添加 `PostFormMap` 与 `GetPostFormMap` 方法

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Clients can use map for form submission in the request body's `form-data` or `x-www-form-urlencoded`, for example `attr[k1]=v1&attr[k2]=v2&attr[k3]=v3`. The method PostFormMap("attr") can be used to obtain the map `{"k1": "v1", "k2": "v2", "k3": "v3"}`. This method is implemented by referring to `gin.Context.PostFormMap`. Map can be used more conveniently for form data transmission.

zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->