### PR TITLE
Introducing Hertz Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ English | [中文](README_cn.md)
 [![ClosedIssue](https://img.shields.io/github/issues-closed/cloudwego/hertz)](https://github.com/cloudwego/hertz/issues?q=is%3Aissue+is%3Aclosed)
 ![Stars](https://img.shields.io/github/stars/cloudwego/hertz)
 ![Forks](https://img.shields.io/github/forks/cloudwego/hertz)
-
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Hertz%20Guru-006BFF)](https://gurubase.io/g/hertz)
 
 Hertz [həːts] is a high-usability, high-performance and high-extensibility Golang HTTP framework that helps developers build microservices. It was designed with reference to other open-source frameworks like [fasthttp](https://github.com/valyala/fasthttp), [gin](https://github.com/gin-gonic/gin), [echo](https://github.com/labstack/echo) and combined with the internal requirements in ByteDance. At present, it has been widely used inside ByteDance. Nowadays, more and more microservices use Golang. If you have requirements for microservice performance and hope that the framework can fully meet the internal customizable requirements, Hertz will be a good choice.
 ## Basic Features


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Hertz Guru](https://gurubase.io/g/hertz) to Gurubase. Hertz Guru uses the data from this repo and data from the [docs](https://www.cloudwego.io/docs/hertz/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Hertz Guru", which highlights that Hertz now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Hertz Guru in Gurubase, just let me know that's totally fine.
