### PR TITLE
fix: compare `body.Cap()` with `maxKeepBodySize` instead of `body.Len()`

### DIFF
--- a/pkg/common/bytebufferpool/bytebuffer.go
+++ b/pkg/common/bytebufferpool/bytebuffer.go
@@ -61,6 +61,10 @@ func (b *ByteBuffer) Len() int {
 	return len(b.B)
 }
 
+func (b *ByteBuffer) Cap() int {
+	return cap(b.B)
+}
+
 // ReadFrom implements io.ReaderFrom.
 //
 // The function appends all the data read from r to b.

--- a/pkg/common/bytebufferpool/bytebuffer_test.go
+++ b/pkg/common/bytebufferpool/bytebuffer_test.go
@@ -47,6 +47,8 @@ import (
 	"io"
 	"testing"
 	"time"
+
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
 )
 
 func TestByteBufferReadFrom(t *testing.T) {
@@ -73,6 +75,7 @@ func TestByteBufferReadFrom(t *testing.T) {
 		if bbLen != expectedLen {
 			t.Fatalf("unexpected byteBuffer length: %d. Expecting %d", bbLen, expectedLen)
 		}
+		assert.True(t, bb.Cap() >= int(expectedLen))
 		for j := 0; j < i; j++ {
 			start := prefixLen + int64(j)*expectedN
 			b := bb.B[start : start+expectedN]
@@ -104,6 +107,7 @@ func TestByteBufferWriteTo(t *testing.T) {
 			t.Fatalf("unexpected string written %q. Expecting %q", s, expectedS)
 		}
 		w.Reset()
+		assert.True(t, bb.Cap() >= len(expectedS))
 	}
 }
 

--- a/pkg/protocol/request.go
+++ b/pkg/protocol/request.go
@@ -411,7 +411,7 @@ func (req *Request) ResetBody() {
 	req.RemoveMultipartFormFiles()
 	req.CloseBodyStream() //nolint:errcheck
 	if req.body != nil {
-		if req.body.Len() <= req.maxKeepBodySize {
+		if req.body.Cap() <= req.maxKeepBodySize {
 			req.body.Reset()
 			return
 		}

--- a/pkg/protocol/response.go
+++ b/pkg/protocol/response.go
@@ -296,7 +296,7 @@ func (resp *Response) ResetBody() {
 	resp.bodyRaw = nil
 	resp.CloseBodyStream() //nolint:errcheck
 	if resp.body != nil {
-		if resp.body.Len() <= resp.maxKeepBodySize {
+		if resp.body.Cap() <= resp.maxKeepBodySize {
 			resp.body.Reset()
 			return
 		}

--- a/pkg/protocol/response_test.go
+++ b/pkg/protocol/response_test.go
@@ -172,6 +172,26 @@ func TestResponseResetBody(t *testing.T) {
 	assert.Nil(t, resp.body)
 }
 
+func TestResponseBodyReuse(t *testing.T) {
+	resp := Response{}
+	resp.maxKeepBodySize = 1024
+
+	buf := resp.BodyBuffer()
+	// set a big body
+	buf.Write(make([]byte, resp.maxKeepBodySize+1))
+	resp.ResetBody()
+	assert.Nil(t, resp.body)
+	// NOTICE: bytebufferpool may not get a big enough buffer,
+	// so we just mock a new one here
+	resp.body = &bytebufferpool.ByteBuffer{
+		B: make([]byte, 0, resp.maxKeepBodySize+1),
+	}
+	// set a small body
+	buf.Write(make([]byte, 1))
+	resp.ResetBody()
+	assert.Nil(t, resp.body)
+}
+
 func testResponseCopyTo(t *testing.T, src *Response) {
 	var dst Response
 	src.CopyTo(&dst)


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: hertz use http-body-slice's length to compare with `MaxKeepBodySize` to decide if keep it in request/response or put into `requestBodyPool` on `ResetBody()`. 
```
// ResetBody resets request body.
func (req *Request) ResetBody() {
	req.bodyRaw = nil
	req.RemoveMultipartFormFiles()
	req.CloseBodyStream() //nolint:errcheck
	if req.body != nil {
		if req.body.Len() <= req.maxKeepBodySize { // use Length to judge here
			req.body.Reset()
			return
		}
		requestBodyPool.Put(req.body) // big body will be put into buffer pool
		req.body = nil
	}
}
```
However, a big request body (`.Len()>MaxKeepBodySize`) which was firstly put into `requestBodyPool` is still likely to be used in subsequent request, even if the actually request data is small..
```
func (req *Request) BodyBuffer() *bytebufferpool.ByteBuffer {
	if req.body == nil {
		req.body = requestBodyPool.Get() // big body may be reused for small request
	}
	req.bodyRaw = nil
	return req.body
}
```
therefore, once the subsequent request finish and back to `ResetBody()` logic, although its body's **Cap is much larger than Len**, it will still be kept in request/repsponse, which may introduce memory leak.

zh(optional): 将 `MaxKeepBody` 的判定条件由 `Len()` 改成 `Cap()`

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->