### PR TITLE
test(pkg/protocol): fix unstable AcquireResponse coverage

### DIFF
--- a/pkg/protocol/response_test.go
+++ b/pkg/protocol/response_test.go
@@ -226,12 +226,15 @@ func TestResponseSwapResponseBody(t *testing.T) {
 
 func TestResponseAcquireResponse(t *testing.T) {
 	t.Parallel()
-	resp1 := AcquireResponse()
-	assert.NotNil(t, resp1)
-	resp1.SetBody([]byte("test"))
-	resp1.SetStatusCode(consts.StatusOK)
-	ReleaseResponse(resp1)
-	assert.Nil(t, resp1.body)
+	for i := 0; i < 10; i++ {
+		resp1 := AcquireResponse()
+		assert.NotNil(t, resp1)
+		assert.Nil(t, resp1.body)
+
+		resp1.SetBody([]byte("test"))
+		resp1.SetStatusCode(consts.StatusOK)
+		ReleaseResponse(resp1)
+	}
 }
 
 type closeBuffer struct {
@@ -263,6 +266,8 @@ func TestSetBodyStreamNoReset(t *testing.T) {
 
 func TestRespSafeCopy(t *testing.T) {
 	resp := AcquireResponse()
+	defer ReleaseResponse(resp)
+
 	resp.bodyRaw = make([]byte, 1)
 	resps := make([]*Response, 10)
 	for i := 0; i < 10; i++ {
@@ -278,6 +283,8 @@ func TestRespSafeCopy(t *testing.T) {
 
 func TestResponse_HijackWriter(t *testing.T) {
 	resp := AcquireResponse()
+	defer ReleaseResponse(resp)
+
 	buf := new(bytes.Buffer)
 	isFinal := false
 	resp.HijackWriter(&mock.ExtWriter{Buf: buf, IsFinal: &isFinal})


### PR DESCRIPTION
see: https://github.com/cloudwego/hertz/pull/1302/checks

#### What type of PR is this?
test

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->