### PR TITLE
perf: optimize LowercaseBytes with loop unrolling

### DIFF
--- a/internal/bytesconv/bytesconv.go
+++ b/internal/bytesconv/bytesconv.go
@@ -59,9 +59,22 @@ const (
 var hexIntBufPool sync.Pool
 
 func LowercaseBytes(b []byte) {
-	for i := 0; i < len(b); i++ {
-		p := &b[i]
-		*p = ToLowerTable[*p]
+	// Process in chunks of 8 bytes for better CPU cache utilization
+	n := len(b)
+	for i := 0; i+8 <= n; i += 8 {
+		b[i] = ToLowerTable[b[i]]
+		b[i+1] = ToLowerTable[b[i+1]]
+		b[i+2] = ToLowerTable[b[i+2]]
+		b[i+3] = ToLowerTable[b[i+3]]
+		b[i+4] = ToLowerTable[b[i+4]]
+		b[i+5] = ToLowerTable[b[i+5]]
+		b[i+6] = ToLowerTable[b[i+6]]
+		b[i+7] = ToLowerTable[b[i+7]]
+	}
+
+	// Process remaining bytes
+	for i := (n / 8) * 8; i < n; i++ {
+		b[i] = ToLowerTable[b[i]]
 	}
 }
 


### PR DESCRIPTION
Optimize byte case conversion using 8-byte chunk processing to reduce loop overhead and improve CPU cache utilization.

This optimization is especially beneficial in high-throughput HTTP servers where string/byte case conversion is a common operation.

Benchmark code here: https://gist.github.com/thevilledev/8c79f83cbf150722a0f0f6618536138a

Output:

```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/hertz/internal/bytesconv
cpu: Apple M1 Pro
BenchmarkLowercaseHTTPHeaders/Original_SingleShortHeader-8              53530410                21.92 ns/op           24 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/Optimized_SingleShortHeader-8             53644570                21.62 ns/op           24 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/OriginalNoAlloc_SingleShortHeader-8       163260428                7.358 ns/op           0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/OptimizedNoAlloc_SingleShortHeader-8      131213822                9.144 ns/op           0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/Original_SingleLongHeader-8               32666172                37.99 ns/op           64 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/Optimized_SingleLongHeader-8              31773139                35.81 ns/op           64 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/OriginalNoAlloc_SingleLongHeader-8        57897478                20.78 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/OptimizedNoAlloc_SingleLongHeader-8       61378326                19.49 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/Original_MultipleHeaders-8                26105967                44.98 ns/op           80 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/Optimized_MultipleHeaders-8               28006002                43.15 ns/op           80 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/OriginalNoAlloc_MultipleHeaders-8         43841622                28.15 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/OptimizedNoAlloc_MultipleHeaders-8        47760242                24.90 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/Original_HeadersWithMixedCase-8           26374712                44.94 ns/op           80 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/Optimized_HeadersWithMixedCase-8          27039484                43.63 ns/op           80 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/OriginalNoAlloc_HeadersWithMixedCase-8            43761016                27.40 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/OptimizedNoAlloc_HeadersWithMixedCase-8           48120782                26.83 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/Original_LongHeaders-8                            11535018               106.8 ns/op           192 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/Optimized_LongHeaders-8                           14323106                85.55 ns/op          192 B/op          1 allocs/op
BenchmarkLowercaseHTTPHeaders/OriginalNoAlloc_LongHeaders-8                     16313407                72.38 ns/op            0 B/op          0 allocs/op
BenchmarkLowercaseHTTPHeaders/OptimizedNoAlloc_LongHeaders-8                    21135194                56.72 ns/op            0 B/op          0 allocs/op
```

#### What type of PR is this?

Performance improvement.

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->