### PR TITLE
fix(hz): crash occurred when calling the appendDeprecationSuffix()

### DIFF
--- a/cmd/hz/generator/client.go
+++ b/cmd/hz/generator/client.go
@@ -90,7 +90,9 @@ func (pkgGen *HttpPackageGenerator) genClient(pkg *HttpPackage, clientDir string
 		}
 		if len(pkgGen.UseDir) != 0 {
 			oldModelDir := filepath.Clean(filepath.Join(pkgGen.ProjPackage, pkgGen.ModelDir))
+			oldModelDir = filepath.ToSlash(oldModelDir)
 			newModelDir := filepath.Clean(pkgGen.UseDir)
+			newModelDir = filepath.ToSlash(newModelDir)
 			for _, m := range client.ClientMethods {
 				for _, mm := range m.Models {
 					mm.Package = strings.Replace(mm.Package, oldModelDir, newModelDir, 1)

--- a/cmd/hz/generator/handler.go
+++ b/cmd/hz/generator/handler.go
@@ -169,7 +169,9 @@ func (pkgGen *HttpPackageGenerator) processHandler(handler *Handler, root *Route
 
 	if len(pkgGen.UseDir) != 0 {
 		oldModelDir := filepath.Clean(filepath.Join(pkgGen.ProjPackage, pkgGen.ModelDir))
+		oldModelDir = filepath.ToSlash(oldModelDir)
 		newModelDir := filepath.Clean(pkgGen.UseDir)
+		newModelDir = filepath.ToSlash(newModelDir)
 		for _, m := range handler.Methods {
 			for _, mm := range m.Models {
 				mm.Package = strings.Replace(mm.Package, oldModelDir, newModelDir, 1)

--- a/cmd/hz/protobuf/plugin.go
+++ b/cmd/hz/protobuf/plugin.go
@@ -435,7 +435,7 @@ func genMessage(g *protogen.GeneratedFile, f *fileInfo, m *messageInfo, rmTags R
 
 	// Message type declaration.
 	g.Annotate(m.GoIdent.GoName, m.Location)
-	leadingComments := appendDeprecationSuffix(m.Comments.Leading,
+	leadingComments := appendDeprecationSuffix(m.Comments.Leading, f.Desc,
 		m.Desc.Options().(*descriptorpb.MessageOptions).GetDeprecated())
 	g.P(leadingComments,
 		"type ", m.GoIdent, " struct {")
@@ -529,7 +529,7 @@ func genMessageField(g *protogen.GeneratedFile, f *fileInfo, m *messageInfo, fie
 		name = WeakFieldPrefix_goname + name
 	}
 	g.Annotate(m.GoIdent.GoName+"."+name, field.Location)
-	leadingComments := appendDeprecationSuffix(field.Comments.Leading,
+	leadingComments := appendDeprecationSuffix(field.Comments.Leading, f.Desc,
 		field.Desc.Options().(*descriptorpb.FieldOptions).GetDeprecated())
 	g.P(leadingComments,
 		name, " ", goType, tags,

--- a/cmd/hz/protobuf/plugin_stubs.go
+++ b/cmd/hz/protobuf/plugin_stubs.go
@@ -205,7 +205,7 @@ func genExtensions(g *protogen.GeneratedFile, f *fileInfo)
 func genReflectFileDescriptor(gen *protogen.Plugin, g *protogen.GeneratedFile, f *fileInfo)
 
 //go:linkname appendDeprecationSuffix google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo.appendDeprecationSuffix
-func appendDeprecationSuffix(prefix protogen.Comments, deprecated bool) protogen.Comments
+func appendDeprecationSuffix(prefix protogen.Comments, parentFile protoreflect.FileDescriptor, deprecated bool) protogen.Comments
 
 //go:linkname genMessageDefaultDecls google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo.genMessageDefaultDecls
 func genMessageDefaultDecls(g *protogen.GeneratedFile, f *fileInfo, m *messageInfo)


### PR DESCRIPTION
protobuf-go在1.29开始，appendDeprecationSuffix()这个的参数变了，增加了1个参数，
导致hz使用新版本的protobuf-go依赖时，发生错误。
但是，最新的hz修改go.mod中，将protobuf-go从1.28更新为1.34.1

```
plugin protoc_gen_hertz returns error: exit status 1, cause:
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x58 pc=0x8f0a14]
goroutine 1 [running]:
google.golang.org/protobuf/cmd/protoc-gen-go/internal_gengo.appendDeprecationSuffix({0xc00002b040, 0x44}, {0x0, 0xc000fe4210}, 0x40)
protobuf-go/cmd/protoc-gen-go/internal_gengo/main.go:908 +0x34

github.com/cloudwego/hertz/cmd/hz/protobuf.genMessage(0xc000fd1800, 0xc000c3ea10, 0xc000fde1c0, {0x0, 0x0, 0x0})
hertz/cmd/hz/protobuf/plugin.go:438 +0x235
```