### PR TITLE
fix(hz): the --use option is incorrect on windows system

### DIFF
--- a/cmd/hz/generator/client.go
+++ b/cmd/hz/generator/client.go
@@ -90,7 +90,9 @@ func (pkgGen *HttpPackageGenerator) genClient(pkg *HttpPackage, clientDir string
 		}
 		if len(pkgGen.UseDir) != 0 {
 			oldModelDir := filepath.Clean(filepath.Join(pkgGen.ProjPackage, pkgGen.ModelDir))
+			oldModelDir = filepath.ToSlash(oldModelDir)
 			newModelDir := filepath.Clean(pkgGen.UseDir)
+			newModelDir = filepath.ToSlash(newModelDir)
 			for _, m := range client.ClientMethods {
 				for _, mm := range m.Models {
 					mm.Package = strings.Replace(mm.Package, oldModelDir, newModelDir, 1)

--- a/cmd/hz/generator/handler.go
+++ b/cmd/hz/generator/handler.go
@@ -169,7 +169,9 @@ func (pkgGen *HttpPackageGenerator) processHandler(handler *Handler, root *Route
 
 	if len(pkgGen.UseDir) != 0 {
 		oldModelDir := filepath.Clean(filepath.Join(pkgGen.ProjPackage, pkgGen.ModelDir))
+		oldModelDir = filepath.ToSlash(oldModelDir)
 		newModelDir := filepath.Clean(pkgGen.UseDir)
+		newModelDir = filepath.ToSlash(newModelDir)
 		for _, m := range handler.Methods {
 			for _, mm := range m.Models {
 				mm.Package = strings.Replace(mm.Package, oldModelDir, newModelDir, 1)


### PR DESCRIPTION
使用--use参数时：
windows系统环境下，filepath.Clean()之后是windows风格的`\`路径分隔符，而mm.Package存的是`/`，因而需要ToSlash()