### PR TITLE
wip feat(hz): support fetch template config for remote repo

### DIFF
--- a/cmd/hz/config/argument.go
+++ b/cmd/hz/config/argument.go
@@ -57,6 +57,8 @@ type Argument struct {
 	Use         string
 	NeedGoMod   bool
 
+	Branch string
+
 	JSONEnumStr          bool
 	QueryEnumAsInt       bool
 	UnsetOmitempty       bool

--- a/cmd/hz/generator/package.go
+++ b/cmd/hz/generator/package.go
@@ -85,15 +85,13 @@ func (pkgGen *HttpPackageGenerator) Init() error {
 	customConfig := TemplateConfig{}
 	// unmarshal from user-defined config file if it exists
 	if pkgGen.ConfigPath != "" {
-		configPath := pkgGen.ConfigPath // 使用局部变量以避免修改原始结构体字段
+		configPath := pkgGen.ConfigPath
 		info, err := os.Stat(configPath)
 		if err != nil {
 			return fmt.Errorf("invalid custom package path '%s': %v", configPath, err)
 		}
 
-		// 如果它是一个目录，则自动附加约定的配置文件名
 		if info.IsDir() {
-			// 假设用于包模板的约定文件名为 'package.yaml'
 			configPath = filepath.Join(configPath, "package.yaml")
 		}
 

--- a/cmd/hz/util/tool_install.go
+++ b/cmd/hz/util/tool_install.go
@@ -149,3 +149,18 @@ func CheckAndUpdateThriftgo() error {
 
 	return nil
 }
+
+// RunCmd executes an external command and handles its output.
+func RunCmd(dir, name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	logs.Infof("Executing: %s %s", name, strings.Join(args, " "))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("'%s %s' failed with error: %v\nOutput:\n%s", name, strings.Join(args, " "), err, string(out))
+	}
+	logs.Debugf(string(out))
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
feat

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
feat(hz): 支持从远程仓库获取模板配置

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
This PR introduces the capability for `hz` to fetch template configurations directly from remote Git repositories. Previously, `hz` only supported local file paths for template-related arguments like `--customize_layout`, `--customize_package`, and `--customize_layout_data`. This made it cumbersome for teams to share, version, and manage templates consistently.

With this change:
1.  **Remote URL Support**: Users can now provide HTTPS or SSH Git URLs (e.g., `https://github.com/my-org/my-template.git`) directly to template-related flags.
2.  **Branch Selection**: A new `--branch` flag is added, allowing users to specify which branch of the remote repository to use for fetching templates.
3.  **Automatic Cloning**: `hz` will automatically `git clone --depth 1` the specified remote repository (and branch if provided) into a temporary local directory.
4.  **Seamless Integration**: The internal template processing logic (`GenerateLayout`, `HttpPackageGenerator.Init`) will operate on these locally cloned temporary files, making the origin (remote vs. local) transparent to the existing generation process.
5.  **Auto Cleanup**: A cleanup function is registered to ensure that the temporary directories created for cloning are automatically removed upon command completion, whether successful or failed.
6.  **Convention Over Configuration for Directories**: If a template path (local or remote) points to a directory, `hz` will now automatically look for specific configuration files within that directory:
    *   For `--customize_layout`, it will look for `layout.yaml`.
    *   For `--customize_package`, it will look for `package.yaml`.
    *   For `--customize_layout_data`, it will look for `data.json`.
    This significantly improves user experience by reducing the need for explicit file paths when using well-structured template repositories.

This feature greatly enhances `hz`'s flexibility and usability for collaborative development, allowing teams to maintain and distribute `hz` templates more efficiently through version control systems.

zh:
此 PR 引入了 `hz` 工具直接从远程 Git 仓库获取模板配置的能力。此前，`hz` 的模板相关参数（如 `--customize_layout`, `--customize_package`, 和 `--customize_layout_data`）只支持本地文件路径。

通过此次变更：
1.  **支持远程 URL**：用户现在可以直接将 HTTPS 或 SSH Git URL（例如 `https://github.com/my-org/my-template.git`）传递给模板相关标志。
2.  **分支选择**：新增 `--branch` 标志，允许用户指定从远程仓库的哪个分支拉取模板。
3.  **自动克隆**：`hz` 将自动执行 `git clone --depth 1` 命令（如果指定了分支则带上 `--branch` 参数），将指定的远程仓库克隆到一个临时本地目录中。
4.  **无缝集成**：内部的模板处理逻辑（如 `GenerateLayout`, `HttpPackageGenerator.Init`）将操作这些本地克隆的临时文件，使现有生成过程对模板来源（远程或本地）无感知。
5.  **自动清理**：注册清理函数，确保在命令完成（无论成功或失败）后，为克隆而创建的临时目录能够被自动删除。
6.  **目录约定优先于配置**：如果模板路径（无论是本地还是远程）指向一个目录，`hz` 现在将自动在该目录内查找特定的配置文件：
    *   对于 `--customize_layout`，它将查找 `layout.yaml`。
    *   对于 `--customize_package`，它将查找 `package.yaml`。
    *   对于 `--customize_layout_data`，它将查找 `data.json`。




#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/cloudwego/hertz/issues/1370

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io]
-->
