### PR TITLE
fix(tagexpr): prevent stack overflow with pb unexported fields

### DIFF
--- a/internal/tagexpr/tagexpr_test.go
+++ b/internal/tagexpr/tagexpr_test.go
@@ -15,6 +15,7 @@
 package tagexpr_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -22,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cloudwego/hertz/internal/tagexpr"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func assertEqual(t *testing.T, v1, v2 interface{}, msgs ...interface{}) {
@@ -850,6 +852,20 @@ func TestIssue5(t *testing.T) {
 		return nil
 	})
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHertzIssue1410(t *testing.T) {
+	type HelloReq struct {
+		Meta *structpb.Struct `protobuf:"bytes,2,opt,name=meta,proto3" form:"meta" json:"meta,omitempty"`
+	}
+	x := &HelloReq{}
+	if err := json.Unmarshal([]byte(`{"meta": {"test": "value"}}`), x); err != nil {
+		t.Fatal(err)
+	}
+	te := tagexpr.New("test").MustRun(x)
+	if err := te.Range(func(eh *tagexpr.ExprHandler) error { return nil }); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fixes #1410

#### What type of PR is this?
fix
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->