### PR TITLE
refactor(binding): deprecate `StructValidator`

### DIFF
--- a/internal/test/mock/binder/binder.go
+++ b/internal/test/mock/binder/binder.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package binder
+
+import (
+	"github.com/cloudwego/hertz/pkg/protocol"
+	"github.com/cloudwego/hertz/pkg/route/param"
+)
+
+// Binder provides a mock implementation of the Binder interface for testing.
+type Binder struct {
+	ValidateError error // Error to return from Validate method
+}
+
+// NewBinder creates a new mock binder.
+func NewBinder() *Binder {
+	return &Binder{}
+}
+
+// NewBinderWithValidateError creates a new mock binder that returns the specified error from Validate.
+func NewBinderWithValidateError(err error) *Binder {
+	return &Binder{ValidateError: err}
+}
+
+func (m *Binder) Name() string {
+	return "test binder"
+}
+
+func (m *Binder) Bind(request *protocol.Request, i interface{}, params param.Params) error {
+	return nil
+}
+
+func (m *Binder) BindAndValidate(request *protocol.Request, i interface{}, params param.Params) error {
+	return nil
+}
+
+func (m *Binder) BindQuery(request *protocol.Request, i interface{}) error {
+	return nil
+}
+
+func (m *Binder) BindHeader(request *protocol.Request, i interface{}) error {
+	return nil
+}
+
+func (m *Binder) BindPath(request *protocol.Request, i interface{}, params param.Params) error {
+	return nil
+}
+
+func (m *Binder) BindForm(request *protocol.Request, i interface{}) error {
+	return nil
+}
+
+func (m *Binder) BindJSON(request *protocol.Request, i interface{}) error {
+	return nil
+}
+
+func (m *Binder) BindProtobuf(request *protocol.Request, i interface{}) error {
+	return nil
+}
+
+func (m *Binder) Validate(request *protocol.Request, i interface{}) error {
+	if m.ValidateError != nil {
+		return m.ValidateError
+	}
+	return nil
+}

--- a/internal/test/mock/binder/binder_test.go
+++ b/internal/test/mock/binder/binder_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package binder
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
+)
+
+func TestNewBinder(t *testing.T) {
+	binder := NewBinder()
+	assert.DeepEqual(t, "test binder", binder.Name())
+	assert.Nil(t, binder.ValidateError)
+
+	// Test all binding methods return nil
+	assert.Nil(t, binder.Bind(nil, nil, nil))
+	assert.Nil(t, binder.BindAndValidate(nil, nil, nil))
+	assert.Nil(t, binder.BindQuery(nil, nil))
+	assert.Nil(t, binder.BindHeader(nil, nil))
+	assert.Nil(t, binder.BindPath(nil, nil, nil))
+	assert.Nil(t, binder.BindForm(nil, nil))
+	assert.Nil(t, binder.BindJSON(nil, nil))
+	assert.Nil(t, binder.BindProtobuf(nil, nil))
+	assert.Nil(t, binder.Validate(nil, nil))
+}
+
+func TestNewBinderWithValidateError(t *testing.T) {
+	testErr := errors.New("test error")
+	binder := NewBinderWithValidateError(testErr)
+	assert.DeepEqual(t, testErr, binder.ValidateError)
+}
+
+func TestBinderValidate(t *testing.T) {
+	// Test no error
+	binder1 := NewBinder()
+	assert.Nil(t, binder1.Validate(nil, nil))
+
+	// Test with error
+	testErr := errors.New("validation failed")
+	binder2 := NewBinderWithValidateError(testErr)
+	assert.DeepEqual(t, testErr, binder2.Validate(nil, nil))
+}

--- a/pkg/app/server/binding/binder.go
+++ b/pkg/app/server/binding/binder.go
@@ -48,11 +48,12 @@ import (
 type Binder interface {
 	Name() string
 	Bind(*protocol.Request, interface{}, param.Params) error
-	BindAndValidate(*protocol.Request, interface{}, param.Params) error
 	BindQuery(*protocol.Request, interface{}) error
 	BindHeader(*protocol.Request, interface{}) error
 	BindPath(*protocol.Request, interface{}, param.Params) error
 	BindForm(*protocol.Request, interface{}) error
 	BindJSON(*protocol.Request, interface{}) error
 	BindProtobuf(*protocol.Request, interface{}) error
+
+	Validate(*protocol.Request, interface{}) error
 }

--- a/pkg/app/server/binding/binder_test.go
+++ b/pkg/app/server/binding/binder_test.go
@@ -969,7 +969,7 @@ func TestValidate_MultipleValidate(t *testing.T) {
 	req := newMockRequest().
 		SetRequestURI("http://foobar.com?a=9")
 	var result Test1
-	err := DefaultBinder().BindAndValidate(req.Req, &result, nil)
+	err := BindAndValidate(req.Req, &result, nil)
 	if err == nil {
 		t.Fatalf("expected an error, but get nil")
 	}
@@ -1040,7 +1040,7 @@ func TestBind_NonStruct(t *testing.T) {
 		t.Error(err)
 	}
 
-	err = DefaultBinder().BindAndValidate(req.Req, &id, nil)
+	err = BindAndValidate(req.Req, &id, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1211,7 +1211,7 @@ func TestBind_PreBind(t *testing.T) {
 	if err == nil {
 		t.Error("expect an error, but get nil")
 	}
-	err = DefaultBinder().BindAndValidate(req.Req, &result, nil)
+	err = BindAndValidate(req.Req, &result, nil)
 	if err == nil {
 		t.Error("expect an error, but get nil")
 	}
@@ -1229,7 +1229,7 @@ func TestBind_BindProtobuf(t *testing.T) {
 		SetBody(body)
 
 	result := testdata.HertzReq{}
-	err = DefaultBinder().BindAndValidate(req.Req, &result, nil)
+	err = BindAndValidate(req.Req, &result, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1549,14 +1549,14 @@ func Test_Issue964(t *testing.T) {
 	}
 	r := newMockRequest().SetBody([]byte("{\n  \"startAt\": \"2006-01-02T15:04:05+07:00\"\n}")).SetJSONContentType()
 	var req CreateReq
-	err := DefaultBinder().BindAndValidate(r.Req, &req, nil)
+	err := BindAndValidate(r.Req, &req, nil)
 	if err != nil {
 		t.Error(err)
 	}
 	assert.DeepEqual(t, "2006-01-02 15:04:05 +0700 +0700", req.StartAt.String())
 	r = newMockRequest()
 	req = CreateReq{}
-	err = DefaultBinder().BindAndValidate(r.Req, &req, nil)
+	err = BindAndValidate(r.Req, &req, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/app/server/binding/config.go
+++ b/pkg/app/server/binding/config.go
@@ -67,8 +67,19 @@ type BindConfig struct {
 	// NOTE:
 	// time.Time is registered by default
 	TypeUnmarshalFuncs map[reflect.Type]inDecoder.CustomizeDecodeFunc
+
 	// Validator is used to validate for BindAndValidate()
+	//
+	// Deprecated: use ValidatorFunc instead. You can create a ValidatorFunc
+	// from a StructValidator using MakeValidatorFunc()
 	Validator StructValidator
+
+	// ValidatorFunc is used to validate structs with custom validation logic.
+	// It replaces the deprecated Validator field and provides request context.
+	// NOTE:
+	//   The default is nil. If set, this takes precedence over the Validator field.
+	//   The function signature allows access to the request for context-aware validation.
+	ValidatorFunc func(req *protocol.Request, v any) error
 }
 
 func NewBindConfig() *BindConfig {
@@ -142,11 +153,17 @@ func (config *BindConfig) UseStdJSONUnmarshaler() {
 
 type ValidateErrFactory func(fieldSelector, msg string) error
 
+// ValidateConfig configures validation behavior for the built-in StructValidator.
+//
+// Deprecated: Use WithCustomValidatorFunc with a custom validation function instead.
 type ValidateConfig struct {
 	ValidateTag string
 	ErrFactory  ValidateErrFactory
 }
 
+// NewValidateConfig creates a new ValidateConfig.
+//
+// Deprecated: Use WithCustomValidatorFunc with a custom validation function instead.
 func NewValidateConfig() *ValidateConfig {
 	return &ValidateConfig{}
 }
@@ -156,16 +173,22 @@ func NewValidateConfig() *ValidateConfig {
 //
 //	If force=true, allow to cover the existed same funcName.
 //	MustRegValidateFunc will remain in effect once it has been called.
+//
+// Deprecated: Use WithCustomValidatorFunc with a custom validation function instead.
 func (config *ValidateConfig) MustRegValidateFunc(funcName string, fn func(args ...interface{}) error, force ...bool) {
 	exprValidator.MustRegFunc(funcName, fn, force...)
 }
 
 // SetValidatorErrorFactory customizes the factory of validation error.
+//
+// Deprecated: Use WithCustomValidatorFunc with a custom validation function instead.
 func (config *ValidateConfig) SetValidatorErrorFactory(errFactory ValidateErrFactory) {
 	config.ErrFactory = errFactory
 }
 
-// SetValidatorTag customizes the factory of validation error.
+// SetValidatorTag customizes the validation tag.
+//
+// Deprecated: Use WithCustomValidatorFunc with a custom validation function instead.
 func (config *ValidateConfig) SetValidatorTag(tag string) {
 	config.ValidateTag = tag
 }

--- a/pkg/app/server/binding/internal/decoder/tag.go
+++ b/pkg/app/server/binding/internal/decoder/tag.go
@@ -60,12 +60,8 @@ func head(str, sep string) (head, tail string) {
 	return str[:idx], str[idx+len(sep):]
 }
 
-func lookupFieldTags(field reflect.StructField, parentJSONName string, config *DecodeConfig) ([]TagInfo, string, bool) {
+func lookupFieldTags(field reflect.StructField, parentJSONName string, config *DecodeConfig) ([]TagInfo, string) {
 	var ret []string
-	var needValidate bool
-	if _, ok := field.Tag.Lookup(config.ValidateTag); ok {
-		needValidate = true
-	}
 	tags := []string{pathTag, formTag, queryTag, cookieTag, headerTag, jsonTag, rawBodyTag, fileNameTag}
 	for _, tag := range tags {
 		if _, ok := field.Tag.Lookup(tag); ok {
@@ -117,7 +113,7 @@ func lookupFieldTags(field reflect.StructField, parentJSONName string, config *D
 		newParentJSONName = strings.TrimPrefix(parentJSONName+"."+field.Name, ".")
 	}
 
-	return tagInfos, newParentJSONName, needValidate
+	return tagInfos, newParentJSONName
 }
 
 func getDefaultFieldTags(field reflect.StructField, parentJSONName string) (tagInfos []TagInfo, newParentJSONName string) {

--- a/pkg/app/server/binding/internal/decoder/util.go
+++ b/pkg/app/server/binding/internal/decoder/util.go
@@ -81,7 +81,6 @@ func stringToValue(elemType reflect.Type, text string, req *protocol.Request, pa
 		}
 		return v, nil
 	}
-
 }
 
 func tryTextUnmarshaler(v reflect.Value, s string) bool {

--- a/pkg/app/server/binding/reflect.go
+++ b/pkg/app/server/binding/reflect.go
@@ -64,10 +64,10 @@ func checkPointer(rv reflect.Value) error {
 	return nil
 }
 
-func dereferPointer(rv reflect.Value) reflect.Type {
-	rt := rv.Type()
-	for rt.Kind() == reflect.Ptr {
-		rt = rt.Elem()
+// dereferenceType recursively dereferences pointer types to get the underlying type.
+func dereferenceType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
 	}
-	return rt
+	return t
 }

--- a/pkg/app/server/binding/reflect_test.go
+++ b/pkg/app/server/binding/reflect_test.go
@@ -68,20 +68,14 @@ func TestReflect_CheckPointer(t *testing.T) {
 	}
 }
 
-func TestReflect_DereferPointer(t *testing.T) {
+func TestReflect_DereferenceType(t *testing.T) {
 	var foo1 ****foo
 	foo1Val := reflect.ValueOf(foo1)
-	rt := dereferPointer(foo1Val)
-	if rt.Kind() == reflect.Ptr {
-		t.Errorf("expect non-pointer type, but get pointer")
-	}
+	rt := dereferenceType(foo1Val.Type())
 	assert.DeepEqual(t, "foo", rt.Name())
 
 	var foo2 foo
 	foo2Val := reflect.ValueOf(foo2)
-	rt2 := dereferPointer(foo2Val)
-	if rt2.Kind() == reflect.Ptr {
-		t.Errorf("expect non-pointer type, but get pointer")
-	}
+	rt2 := dereferenceType(foo2Val.Type())
 	assert.DeepEqual(t, "foo", rt2.Name())
 }

--- a/pkg/app/server/binding/validator_test.go
+++ b/pkg/app/server/binding/validator_test.go
@@ -18,6 +18,8 @@ package binding
 
 import (
 	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/test/assert"
 )
 
 func Test_ValidateStruct(t *testing.T) {
@@ -57,8 +59,8 @@ func Test_ValidateTag(t *testing.T) {
 	req := newMockRequest().
 		SetRequestURI("http://foobar.com?age=135").
 		SetHeaders("h", "header")
-	err = binder.BindAndValidate(req.Req, user, nil)
-	if err == nil {
-		t.Fatalf("expected an error, but got nil")
-	}
+	err = binder.Bind(req.Req, user, nil)
+	assert.Nil(t, err)
+	err = binder.Validate(req.Req, user)
+	assert.NotNil(t, err)
 }

--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -358,6 +358,8 @@ func WithBindConfig(bc *binding.BindConfig) config.Option {
 }
 
 // WithValidateConfig sets validate config.
+//
+// Deprecated: Use WithCustomValidatorFunc with a custom validation function instead.
 func WithValidateConfig(vc *binding.ValidateConfig) config.Option {
 	return config.Option{F: func(o *config.Options) {
 		o.ValidateConfig = vc
@@ -365,16 +367,37 @@ func WithValidateConfig(vc *binding.ValidateConfig) config.Option {
 }
 
 // WithCustomBinder sets customized Binder.
+//
+// Priority: CustomBinder has the highest priority and will override any BindConfig
+// and CustomValidator settings when present. If CustomBinder is set, both the default
+// binder initialization and validator initialization are completely bypassed.
+//
+// Priority order (highest to lowest):
+//  1. CustomBinder (this option) - completely overrides all binding and validation logic
+//  2. CustomValidator/WithCustomValidatorFunc - sets custom validation for default binder
+//  3. BindConfig - configures the default binder behavior
+//  4. ValidateConfig - legacy validation configuration (deprecated)
+//  5. Default binding and validation behavior
+//
+// Note: When CustomBinder is used, validation logic must be implemented within the
+// custom binder's BindAndValidate method, as CustomValidator is ignored.
 func WithCustomBinder(b binding.Binder) config.Option {
 	return config.Option{F: func(o *config.Options) {
 		o.CustomBinder = b
 	}}
 }
 
-// WithCustomValidator sets customized Binder.
+// WithCustomValidator sets customized StructValidator.
+//
+// Deprecated: Use WithCustomValidatorFunc instead.
 func WithCustomValidator(b binding.StructValidator) config.Option {
+	return WithCustomValidatorFunc(binding.MakeValidatorFunc(b))
+}
+
+// WithCustomValidatorFunc sets customized validator function.
+func WithCustomValidatorFunc(vf binding.ValidatorFunc) config.Option {
 	return config.Option{F: func(o *config.Options) {
-		o.CustomValidator = b
+		o.CustomValidator = vf
 	}}
 }
 

--- a/pkg/common/config/option.go
+++ b/pkg/common/config/option.go
@@ -76,9 +76,11 @@ type Options struct {
 	TraceLevel                   interface{}
 	ListenConfig                 *net.ListenConfig
 	BindConfig                   interface{}
-	ValidateConfig               interface{}
 	CustomBinder                 interface{}
 	CustomValidator              interface{}
+
+	// Deprecated: Use CustomValidator with a ValidatorFunc instead
+	ValidateConfig interface{}
 
 	// TransporterNewer is the function to create a transporter.
 	TransporterNewer    func(opt *Options) network.Transporter


### PR DESCRIPTION
Deprecates `StructValidator` interface in favor of `ValidatorFunc` for better flexibility.

**Breaking Changes**
- Added `Validate()` method to `binding.Binder`
- Removed `BindAndValidate()` method from `binding.Binder`
- Removed `SetValidator()` method from `RequestContext` (test-only, added accidentally)

**New Features:**
- `binding.MakeValidatorFunc()` converts `StructValidator` to `ValidatorFunc`
- `server.WithCustomValidator()` calls `binding.MakeValidatorFunc()`
- `server.WithCustomValidatorFunc()` for injecting custom validators

**Migration:**
- No changes needed if not using custom binder/validator
- For custom binders, need to implement `Validate()`
- For custom validators, use `server.WithCustomValidatorFunc()`:

```go
validate := validator.New() // 3rd party validator like github.com/go-playground/validator
h := server.New(server.WithCustomValidatorFunc(func(_ *protocol.Request, req any) error {
    return validate.Struct(req)
}))
```

#### What type of PR is this?
refactor

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->