### PR TITLE
fix(protocol): improve cookie max-age and expires handling

### DIFF
--- a/pkg/protocol/cookie_test.go
+++ b/pkg/protocol/cookie_test.go
@@ -285,7 +285,7 @@ func TestCookiePartitioned(t *testing.T) {
 	}
 }
 
-func TestCookieMaxAge(t *testing.T) {
+func TestCookieMaxAgeExpires(t *testing.T) {
 	t.Parallel()
 
 	var c Cookie
@@ -308,16 +308,28 @@ func TestCookieMaxAge(t *testing.T) {
 	if maxAge != c.MaxAge() {
 		t.Fatalf("max-age ignored")
 	}
+	expectedExpires := time.Date(2009, 11, 10, 23, 0, 0, 0, time.UTC)
+	if !c.Expire().Equal(expectedExpires) {
+		t.Fatalf("expires not parsed correctly. Got %v, expected %v", c.Expire(), expectedExpires)
+	}
+
+	c.SetExpire(time.Time{})
 	s = c.String()
 	if s != "foo=bar; max-age=100" {
 		t.Fatalf("missing max-age in cookie %q", s)
 	}
 
+	c.SetMaxAge(-1)
+	s = c.String()
+	if s != "foo=bar; max-age=0" {
+		t.Fatalf("negative max-age should output 0: %q", s)
+	}
+
 	expires := time.Unix(100, 0)
 	c.SetExpire(expires)
 	s = c.String()
-	if s != "foo=bar; max-age=100" {
-		t.Fatalf("expires should be ignored due to max-age: %q", s)
+	if s != "foo=bar; max-age=0; expires=Thu, 01 Jan 1970 00:01:40 GMT" {
+		t.Fatalf("expires should be included along with negative max-age (output as 0): %q", s)
 	}
 
 	c.SetMaxAge(0)
@@ -364,7 +376,7 @@ func TestCookieParse(t *testing.T) {
 	testCookieParse(t, `foo="bar"`, "foo=bar")
 	testCookieParse(t, `"foo"=bar`, `"foo"=bar`)
 	testCookieParse(t, "foo=bar; Domain=aaa.com; PATH=/foo/bar", "foo=bar; domain=aaa.com; path=/foo/bar")
-	testCookieParse(t, "foo=bar; max-age= 101 ; expires= Tue, 10 Nov 2009 23:00:00 GMT", "foo=bar; max-age=101")
+	testCookieParse(t, "foo=bar; max-age= 101 ; expires= Tue, 10 Nov 2009 23:00:00 GMT", "foo=bar; max-age=101; expires=Tue, 10 Nov 2009 23:00:00 GMT")
 	testCookieParse(t, " xxx = yyy  ; path=/a/b;;;domain=foobar.com ; expires= Tue, 10 Nov 2009 23:00:00 GMT ; ;;",
 		"xxx=yyy; expires=Tue, 10 Nov 2009 23:00:00 GMT; domain=foobar.com; path=/a/b")
 }


### PR DESCRIPTION
This change aligns the cookie handling with Go's `net/http` package.

  - Include both max-age and expires attributes when both are set
  - Handle negative max-age values by outputting "0" to delete cookies

#### What type of PR is this?
fix

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->