### PR TITLE
fix: correct saving of custom file paths

### DIFF
--- a/cmd/hz/generator/custom_files.go
+++ b/cmd/hz/generator/custom_files.go
@@ -280,6 +280,10 @@ func (pkgGen *HttpPackageGenerator) genLoopService(tplInfo *Template, filePathRe
 	if err != nil {
 		return err
 	}
+	// add outputDir if filePath is not an absolute path
+	if !filepath.IsAbs(filePath) {
+		filePath = filepath.Join(pkgGen.OutputDir, filePath)
+	}
 	// determine if a custom file exists
 	exist, err := util.PathExist(filePath)
 	if err != nil {
@@ -402,6 +406,10 @@ func (pkgGen *HttpPackageGenerator) genLoopMethod(tplInfo *Template, filePathRen
 	if err != nil {
 		return err
 	}
+	// add outputDir if filePath is not an absolute path
+	if !filepath.IsAbs(filePath) {
+		filePath = filepath.Join(pkgGen.OutputDir, filePath)
+	}
 	// determine if a custom file exists
 	exist, err := util.PathExist(filePath)
 	if err != nil {
@@ -457,6 +465,10 @@ func (pkgGen *HttpPackageGenerator) genSingleCustomizedFile(tplInfo *Template, f
 	filePath, err := renderFilePath(tplInfo, filePathRenderInfo)
 	if err != nil {
 		return err
+	}
+	// add outputDir if filePath is not an absolute path
+	if !filepath.IsAbs(filePath) {
+		filePath = filepath.Join(pkgGen.OutputDir, filePath)
 	}
 	// determine if a custom file exists
 	exist, err := util.PathExist(filePath)

--- a/cmd/hz/protobuf/plugin.go
+++ b/cmd/hz/protobuf/plugin.go
@@ -288,6 +288,13 @@ func (plugin *Plugin) Handle(req *pluginpb.CodeGeneratorRequest, args *config.Ar
 	// all files that need to be generated are returned to protoc
 	for _, pkgFile := range pkgFiles {
 		filePath := pkgFile.Path
+		if filepath.IsAbs(filePath) {
+			rel, err := filepath.Rel(plugin.OutDir, filePath)
+			if err != nil {
+				return err
+			}
+			filePath = rel
+		}
 		content := pkgFile.Content
 		renderFile := &pluginpb.CodeGeneratorResponse_File{
 			Name:    &filePath,

--- a/cmd/hz/thrift/plugin.go
+++ b/cmd/hz/thrift/plugin.go
@@ -422,7 +422,10 @@ func (plugin *Plugin) InsertTag() ([]*thriftgo_plugin.Generated, error) {
 func (plugin *Plugin) GetResponse(files []generator.File, outputDir string) (*thriftgo_plugin.Response, error) {
 	var contents []*thriftgo_plugin.Generated
 	for _, file := range files {
-		filePath := filepath.Join(outputDir, file.Path)
+		filePath := file.Path
+		if !filepath.IsAbs(file.Path) {
+			filePath = filepath.Join(outputDir, file.Path)
+		}
 		content := &thriftgo_plugin.Generated{
 			Content: file.Content,
 			Name:    &filePath,


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: In the package template, adding {{.ProjectDir}} introduced absolute paths, 
but file generation still used relative paths, which resulted in incorrect 
paths like "/path/to/rel/path/to/rel". This change normalizes path handling 
during processing to ensure generated file paths are correct.

zh(optional): 在 package 模板中 添加 {{.ProjectDir}} ，会给path带上绝对路径，但是生成文件时又按相对路径生成，从而导致路径不正确（“/path/to/rel/path/to/rel ”绝对路径套绝对路径），因此在 handle 时统一路径格式，确保生成文件路径正确。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1428  

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->