### PR TITLE
fix：FakeBool's condition for the default type branch is reversed

### DIFF
--- a/internal/tagexpr/tagexpr.go
+++ b/internal/tagexpr/tagexpr.go
@@ -821,7 +821,7 @@ func FakeBool(v interface{}) bool {
 		return bol
 	default:
 		vv := dereferenceValue(reflect.ValueOf(v))
-		if vv.IsValid() || vv.IsZero() {
+		if !vv.IsValid() || vv.IsZero() {
 			return false
 		}
 		return true


### PR DESCRIPTION
FakeBool's condition for the default type branch is reversed

What type of PR is this?
fix

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

