### PR TITLE
optimize: add default NoRoute and NoMethod handlers to assist troubleshooting

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -402,6 +402,16 @@ func (engine *Engine) Init() error {
 		engine.options.TLS.NextProtos = append(engine.options.TLS.NextProtos, suite.HTTP1)
 	}
 
+	if len(engine.noRoute) == 0 {
+		engine.noRoute = []app.HandlerFunc{hertzRouteNotFound}
+		engine.rebuild404Handlers()
+	}
+
+	if len(engine.noMethod) == 0 {
+		engine.noMethod = []app.HandlerFunc{hertzNotAllowedMethod}
+		engine.rebuild405Handlers()
+	}
+
 	if !atomic.CompareAndSwapUint32(&engine.status, 0, statusInitialized) {
 		return errInitFailed
 	}
@@ -416,6 +426,14 @@ func (engine *Engine) listenAndServe() error {
 	hlog.SystemLogger().Infof("Using network library=%s", engine.GetTransporterName())
 	return engine.transport.ListenAndServe(engine.onData)
 }
+
+// hertzRouteNotFound is default NoRoute handler when users do not configure any handler with NoRoute.
+// it is not an anonymous function, so utils.NameOfFunction could obtain a specific function name to assist troubleshooting.
+func hertzRouteNotFound(c context.Context, ctx *app.RequestContext) {}
+
+// hertzNotAllowedMethod is default NoMethod handler when users do not configure any handler with NoMethod.
+// it is not an anonymous function, so utils.NameOfFunction could obtain a specific function name to assist troubleshooting.
+func hertzNotAllowedMethod(c context.Context, ctx *app.RequestContext) {}
 
 func (c *hijackConn) Close() error {
 	if !c.e.KeepHijackedConns {

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -49,6 +49,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -62,6 +63,7 @@ import (
 	errs "github.com/cloudwego/hertz/pkg/common/errors"
 	"github.com/cloudwego/hertz/pkg/common/test/assert"
 	"github.com/cloudwego/hertz/pkg/common/test/mock"
+	"github.com/cloudwego/hertz/pkg/common/utils"
 	"github.com/cloudwego/hertz/pkg/network"
 	"github.com/cloudwego/hertz/pkg/network/standard"
 	"github.com/cloudwego/hertz/pkg/protocol"
@@ -515,6 +517,17 @@ func TestSetEngineRun(t *testing.T) {
 	assert.True(t, !e.IsRunning())
 	e.MarkAsRunning()
 	assert.True(t, e.IsRunning())
+}
+
+func TestEngine_InitNoRouteAndNoMethod(t *testing.T) {
+	e := NewEngine(config.NewOptions(nil))
+	err := e.Init()
+	assert.Assert(t, err == nil, err)
+	assert.Assert(t, len(e.allNoRoute) == 1, e.allNoRoute)
+	hdlName := utils.NameOfFunction(e.allNoRoute[0])
+	assert.Assert(t, strings.HasSuffix(hdlName, ".hertzRouteNotFound"))
+	hdlName = utils.NameOfFunction(e.allNoMethod[0])
+	assert.Assert(t, strings.HasSuffix(hdlName, ".hertzNotAllowedMethod"))
 }
 
 type mockConn struct{}


### PR DESCRIPTION
#### What type of PR is this?
optimize
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
Users often do not proactively set 404/405 handlers via `engine.NoRoute` and `engine.NoMethod`, resulting in monitoring/logging being unable to obtain valid handler information through `RequestContext.HandlerName`.
Adding default NoRoute and NoMethod handlers provides valid handler information, enabling more effective troubleshooting.
zh(optional):
用户往往不会主动通过 engine.NoRoute 和 engine.NoMethod 设置 404/405 的 Handler，导致监控/打点通过 RequestContext.HandlerName 无法获取到有效的 Handler 信息。
添加默认的 NoRoute 和 NoMethod Handler 来提供有效的 Handler 信息，从而更好地排查问题。

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->