### PR TITLE
fix: reject requests with both Transfer-Encoding and Content-Length headers

### DIFF
--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -160,9 +160,13 @@ var errBothTEAndCL = errors.New("both Transfer-Encoding and Content-Length heade
 // RFC 9112 Section 6.3 Rule 5 treats this as an unrecoverable error (normalization is no longer permitted).
 var errDuplicateCL = errors.New("duplicate Content-Length header with conflicting values")
 
-// errNonChunkedTE is returned when Transfer-Encoding is present but "chunked" is not the final
-// transfer coding. Per RFC 9112 Section 6.3 Rule 4, the server MUST respond with 400 Bad Request.
-var errNonChunkedTE = errors.New("Transfer-Encoding present but chunked is not the final transfer coding")
+// errUnsupportedTE is returned when the Transfer-Encoding value is anything other than "chunked".
+// Like Go net/http and nginx, only "chunked" is accepted to minimize the smuggling attack surface.
+var errUnsupportedTE = errors.New("unsupported Transfer-Encoding: only \"chunked\" is accepted")
+
+// errMultipleTE is returned when more than one Transfer-Encoding header line is present.
+// Different proxies merge multi-line headers inconsistently, making it a smuggling vector.
+var errMultipleTE = errors.New("multiple Transfer-Encoding headers are not allowed")
 
 // request-line = method SP request-target SP HTTP-version CRLF
 func parseFirstLine(h *protocol.RequestHeader, buf []byte) (int, error) {
@@ -310,17 +314,21 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 					if h.ContentLength() >= 0 {
 						return 0, errBothTEAndCL
 					}
-					teSeen = true
-					// identity means no encoding; ignore it for backward compatibility
-					// (removed in RFC 9112 Section 11.2, but still sent by some clients).
-					if !bytes.EqualFold(s.Value, bytestr.StrIdentity) {
-						// Per RFC 9112 Section 6.3 Rule 4, chunked MUST be the final transfer coding.
-						if !isFinalChunked(s.Value) {
-							return 0, errNonChunkedTE
-						}
-						h.InitContentLengthWithValue(-1)
-						h.SetArgBytes(bytestr.StrTransferEncoding, bytestr.StrChunked, protocol.ArgsHasValue)
+					// Multiple Transfer-Encoding header lines are strictly rejected.
+					// Different proxies merge multi-line headers inconsistently, making it a smuggling vector.
+					if teSeen {
+						return 0, errMultipleTE
 					}
+					teSeen = true
+					// Like Go net/http and nginx, only accept "chunked" as the sole
+					// Transfer-Encoding value. Multi-coding values (e.g. "gzip, chunked")
+					// are not used in practice but can cause parsing inconsistencies
+					// across proxies, creating a smuggling vector.
+					if !bytes.EqualFold(s.Value, bytestr.StrChunked) {
+						return 0, errUnsupportedTE
+					}
+					h.InitContentLengthWithValue(-1)
+					h.SetArgBytes(bytestr.StrTransferEncoding, bytestr.StrChunked, protocol.ArgsHasValue)
 					continue
 				}
 				if utils.CaseInsensitiveCompare(s.Key, bytestr.StrTrailer) {
@@ -355,13 +363,3 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 	return s.HLen, nil
 }
 
-// isFinalChunked reports whether "chunked" is the last transfer-coding token in a
-// (possibly comma-separated) Transfer-Encoding field value.
-// Per RFC 9112 Section 6.1 and Section 6.3 Rule 4, chunked MUST be the final coding.
-func isFinalChunked(te []byte) bool {
-	te = bytes.TrimRight(te, " \t")
-	if i := bytes.LastIndexByte(te, ','); i >= 0 {
-		te = bytes.TrimLeft(te[i+1:], " \t")
-	}
-	return bytes.EqualFold(te, bytestr.StrChunked)
-}

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -229,7 +229,11 @@ func validHeaderFieldValue(val []byte) bool {
 func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 	h.InitContentLengthWithValue(-2)
 
-	var teSeen bool // tracks whether any Transfer-Encoding header was seen
+	// teSeen tracks whether any Transfer-Encoding header has been seen.
+	// Each TE line is validated individually rather than merged — multiple TE lines
+	// (e.g. "TE: gzip" then "TE: chunked") are strictly rejected. This is intentional:
+	// different proxies merge multi-line headers inconsistently, making it a smuggling vector.
+	var teSeen bool
 
 	var s ext.HeaderScanner
 	s.B = buf

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -152,12 +152,17 @@ const (
 var errMalformedHTTPRequest = errors.New("malformed HTTP request")
 
 // errBothTEAndCL is returned when a request contains both Transfer-Encoding and Content-Length headers.
-// This is a potential HTTP request smuggling attack vector. See RFC 7230 Section 3.3.3.
+// This is a potential HTTP request smuggling attack vector.
+// See RFC 9112 Section 6.3 Rule 3 and Section 11.2.
 var errBothTEAndCL = errors.New("both Transfer-Encoding and Content-Length headers are present in request: potential HTTP request smuggling")
 
 // errDuplicateCL is returned when a request contains multiple Content-Length headers with different values.
-// See RFC 7230 Section 3.3.2.
+// RFC 9112 Section 6.3 Rule 5 treats this as an unrecoverable error (normalization is no longer permitted).
 var errDuplicateCL = errors.New("duplicate Content-Length header with conflicting values")
+
+// errNonChunkedTE is returned when Transfer-Encoding is present but "chunked" is not the final
+// transfer coding. Per RFC 9112 Section 6.3 Rule 4, the server MUST respond with 400 Bad Request.
+var errNonChunkedTE = errors.New("Transfer-Encoding present but chunked is not the final transfer coding")
 
 // request-line = method SP request-target SP HTTP-version CRLF
 func parseFirstLine(h *protocol.RequestHeader, buf []byte) (int, error) {
@@ -224,6 +229,8 @@ func validHeaderFieldValue(val []byte) bool {
 func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 	h.InitContentLengthWithValue(-2)
 
+	var teSeen bool // tracks whether any Transfer-Encoding header was seen
+
 	var s ext.HeaderScanner
 	s.B = buf
 	s.DisableNormalizing = h.IsDisableNormalizing()
@@ -260,7 +267,7 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 					continue
 				}
 				if utils.CaseInsensitiveCompare(s.Key, bytestr.StrContentLength) {
-					if h.ContentLength() != -1 {
+					if h.ContentLength() != -1 && !teSeen {
 						var nerr error
 						var contentLength int
 						if contentLength, nerr = protocol.ParseContentLength(s.Value); nerr != nil {
@@ -270,7 +277,7 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 							h.InitContentLengthWithValue(-2)
 						} else {
 							// Reject duplicate Content-Length with conflicting values.
-							// See RFC 7230 Section 3.3.2.
+							// RFC 9112 Section 6.3 Rule 5 treats mismatched values as an unrecoverable error.
 							if h.ContentLength() >= 0 && h.ContentLength() != contentLength {
 								return 0, errDuplicateCL
 							}
@@ -278,7 +285,7 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 							h.SetContentLengthBytes(s.Value)
 						}
 					} else {
-						// Transfer-Encoding: chunked already seen; reject per RFC 7230 Section 3.3.3.
+						// Transfer-Encoding already seen; reject per RFC 9112 Section 6.3 Rule 3.
 						return 0, errBothTEAndCL
 					}
 					continue
@@ -294,11 +301,18 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 				}
 			case 't':
 				if utils.CaseInsensitiveCompare(s.Key, bytestr.StrTransferEncoding) {
-					if !bytes.Equal(s.Value, bytestr.StrIdentity) {
-						// Reject if Content-Length was already seen.
-						// See RFC 7230 Section 3.3.3: potential HTTP request smuggling.
-						if h.ContentLength() >= 0 {
-							return 0, errBothTEAndCL
+					// Any TE + CL combination is a potential HTTP request smuggling vector.
+					// Reject per RFC 9112 Section 6.3 Rule 3.
+					if h.ContentLength() >= 0 {
+						return 0, errBothTEAndCL
+					}
+					teSeen = true
+					// identity means no encoding; ignore it for backward compatibility
+					// (removed in RFC 9112 Section 11.2, but still sent by some clients).
+					if !bytes.EqualFold(s.Value, bytestr.StrIdentity) {
+						// Per RFC 9112 Section 6.3 Rule 4, chunked MUST be the final transfer coding.
+						if !isFinalChunked(s.Value) {
+							return 0, errNonChunkedTE
 						}
 						h.InitContentLengthWithValue(-1)
 						h.SetArgBytes(bytestr.StrTransferEncoding, bytestr.StrChunked, protocol.ArgsHasValue)
@@ -335,4 +349,15 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 		h.SetConnectionClose(!ext.HasHeaderValue(v, bytestr.StrKeepAlive))
 	}
 	return s.HLen, nil
+}
+
+// isFinalChunked reports whether "chunked" is the last transfer-coding token in a
+// (possibly comma-separated) Transfer-Encoding field value.
+// Per RFC 9112 Section 6.1 and Section 6.3 Rule 4, chunked MUST be the final coding.
+func isFinalChunked(te []byte) bool {
+	te = bytes.TrimRight(te, " \t")
+	if i := bytes.LastIndexByte(te, ','); i >= 0 {
+		te = bytes.TrimLeft(te[i+1:], " \t")
+	}
+	return bytes.EqualFold(te, bytestr.StrChunked)
 }

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -267,7 +267,7 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 					continue
 				}
 				if utils.CaseInsensitiveCompare(s.Key, bytestr.StrContentLength) {
-					if h.ContentLength() != -1 && !teSeen {
+					if !teSeen {
 						var nerr error
 						var contentLength int
 						if contentLength, nerr = protocol.ParseContentLength(s.Value); nerr != nil {

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -151,6 +151,14 @@ const (
 
 var errMalformedHTTPRequest = errors.New("malformed HTTP request")
 
+// errBothTEAndCL is returned when a request contains both Transfer-Encoding and Content-Length headers.
+// This is a potential HTTP request smuggling attack vector. See RFC 7230 Section 3.3.3.
+var errBothTEAndCL = errors.New("both Transfer-Encoding and Content-Length headers are present in request: potential HTTP request smuggling")
+
+// errDuplicateCL is returned when a request contains multiple Content-Length headers with different values.
+// See RFC 7230 Section 3.3.2.
+var errDuplicateCL = errors.New("duplicate Content-Length header with conflicting values")
+
 // request-line = method SP request-target SP HTTP-version CRLF
 func parseFirstLine(h *protocol.RequestHeader, buf []byte) (int, error) {
 	b, leftb, err := utils.NextLine(buf)
@@ -261,9 +269,17 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 							}
 							h.InitContentLengthWithValue(-2)
 						} else {
+							// Reject duplicate Content-Length with conflicting values.
+							// See RFC 7230 Section 3.3.2.
+							if h.ContentLength() >= 0 && h.ContentLength() != contentLength {
+								return 0, errDuplicateCL
+							}
 							h.InitContentLengthWithValue(contentLength)
 							h.SetContentLengthBytes(s.Value)
 						}
+					} else {
+						// Transfer-Encoding: chunked already seen; reject per RFC 7230 Section 3.3.3.
+						return 0, errBothTEAndCL
 					}
 					continue
 				}
@@ -279,6 +295,11 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 			case 't':
 				if utils.CaseInsensitiveCompare(s.Key, bytestr.StrTransferEncoding) {
 					if !bytes.Equal(s.Value, bytestr.StrIdentity) {
+						// Reject if Content-Length was already seen.
+						// See RFC 7230 Section 3.3.3: potential HTTP request smuggling.
+						if h.ContentLength() >= 0 {
+							return 0, errBothTEAndCL
+						}
 						h.InitContentLengthWithValue(-1)
 						h.SetArgBytes(bytestr.StrTransferEncoding, bytestr.StrChunked, protocol.ArgsHasValue)
 					}

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -362,4 +362,3 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 	}
 	return s.HLen, nil
 }
-

--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -153,7 +153,7 @@ var errMalformedHTTPRequest = errors.New("malformed HTTP request")
 
 // errBothTEAndCL is returned when a request contains both Transfer-Encoding and Content-Length headers.
 // This is a potential HTTP request smuggling attack vector.
-// See RFC 9112 Section 6.3 Rule 3 and Section 11.2.
+// See RFC 9112 Section 6.3 Rule 3.
 var errBothTEAndCL = errors.New("both Transfer-Encoding and Content-Length headers are present in request: potential HTTP request smuggling")
 
 // errDuplicateCL is returned when a request contains multiple Content-Length headers with different values.

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -82,16 +82,61 @@ func TestRequestHeader_Read(t *testing.T) {
 }
 
 func TestRequestHeader_Peek(t *testing.T) {
+	// Requests with both Content-Length and Transfer-Encoding must be rejected
+	// to prevent HTTP request smuggling. See RFC 7230 Section 3.3.3.
 	s := "PUT /foo/bar HTTP/1.1\r\nExpect: 100-continue\r\nUser-Agent: foo\r\nHost: 127.0.0.1\r\nConnection: Keep-Alive\r\nContent-Length: 5\r\nTransfer-Encoding: foo\r\nContent-Type: foo/bar\r\n\r\nabcdef4343"
 	zr := mock.NewZeroCopyReader(s)
 	rh := protocol.RequestHeader{}
-	ReadHeader(&rh, zr)
-	assert.DeepEqual(t, []byte("100-continue"), rh.Peek("Expect"))
-	assert.DeepEqual(t, []byte("127.0.0.1"), rh.Peek("Host"))
-	assert.DeepEqual(t, []byte("foo"), rh.Peek("User-Agent"))
-	assert.DeepEqual(t, []byte("Keep-Alive"), rh.Peek("Connection"))
-	assert.DeepEqual(t, []byte(""), rh.Peek("Content-Length"))
-	assert.DeepEqual(t, []byte("foo/bar"), rh.Peek("Content-Type"))
+	err := ReadHeader(&rh, zr)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Transfer-Encoding") || strings.Contains(err.Error(), "Content-Length"))
+}
+
+func TestRequestHeader_SmugglingRejected(t *testing.T) {
+	// CL then TE: chunked — must be rejected
+	s := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nTransfer-Encoding: chunked\r\n\r\n"
+	zr := mock.NewZeroCopyReader(s)
+	rh := protocol.RequestHeader{}
+	err := ReadHeader(&rh, zr)
+	assert.NotNil(t, err)
+
+	// TE: chunked then CL — must also be rejected
+	s2 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\nContent-Length: 10\r\n\r\n"
+	zr2 := mock.NewZeroCopyReader(s2)
+	rh2 := protocol.RequestHeader{}
+	err2 := ReadHeader(&rh2, zr2)
+	assert.NotNil(t, err2)
+
+	// Duplicate CL with different values — must be rejected
+	s3 := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nContent-Length: 20\r\n\r\n"
+	zr3 := mock.NewZeroCopyReader(s3)
+	rh3 := protocol.RequestHeader{}
+	err3 := ReadHeader(&rh3, zr3)
+	assert.NotNil(t, err3)
+
+	// Duplicate CL with same value — must be accepted
+	s4 := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nContent-Length: 10\r\n\r\n"
+	zr4 := mock.NewZeroCopyReader(s4)
+	rh4 := protocol.RequestHeader{}
+	err4 := ReadHeader(&rh4, zr4)
+	assert.Nil(t, err4)
+	assert.DeepEqual(t, 10, rh4.ContentLength())
+
+	// Only TE: chunked — must be accepted
+	s5 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\n\r\n"
+	zr5 := mock.NewZeroCopyReader(s5)
+	rh5 := protocol.RequestHeader{}
+	err5 := ReadHeader(&rh5, zr5)
+	assert.Nil(t, err5)
+	assert.DeepEqual(t, -1, rh5.ContentLength())
+
+	// Only CL — must be accepted
+	s6 := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 5\r\n\r\n"
+	zr6 := mock.NewZeroCopyReader(s6)
+	rh6 := protocol.RequestHeader{}
+	err6 := ReadHeader(&rh6, zr6)
+	assert.Nil(t, err6)
+	assert.DeepEqual(t, 5, rh6.ContentLength())
 }
 
 func TestRequestHeaderSetGet(t *testing.T) {

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -83,7 +83,7 @@ func TestRequestHeader_Read(t *testing.T) {
 
 func TestRequestHeader_Peek(t *testing.T) {
 	// Requests with both Content-Length and Transfer-Encoding must be rejected
-	// to prevent HTTP request smuggling. See RFC 7230 Section 3.3.3.
+	// to prevent HTTP request smuggling. See RFC 9112 Section 6.3.
 	s := "PUT /foo/bar HTTP/1.1\r\nExpect: 100-continue\r\nUser-Agent: foo\r\nHost: 127.0.0.1\r\nConnection: Keep-Alive\r\nContent-Length: 5\r\nTransfer-Encoding: foo\r\nContent-Type: foo/bar\r\n\r\nabcdef4343"
 	zr := mock.NewZeroCopyReader(s)
 	rh := protocol.RequestHeader{}
@@ -204,6 +204,14 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	rh15 := protocol.RequestHeader{}
 	err15 := ReadHeader(&rh15, zr15)
 	assert.NotNil(t, err15)
+
+	// TE with trailing spaces and mixed case — chunked is final, must be accepted
+	s16 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: gzip, Chunked \t\r\n\r\n"
+	zr16 := mock.NewZeroCopyReader(s16)
+	rh16 := protocol.RequestHeader{}
+	err16 := ReadHeader(&rh16, zr16)
+	assert.Nil(t, err16)
+	assert.DeepEqual(t, -1, rh16.ContentLength())
 }
 
 func TestRequestHeaderSetGet(t *testing.T) {

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -173,6 +173,27 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	rh11 := protocol.RequestHeader{}
 	err11 := ReadHeader(&rh11, zr11)
 	assert.NotNil(t, err11)
+
+	// Invalid Content-Length value — must not panic, error is deferred
+	s12 := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: abc\r\n\r\n"
+	zr12 := mock.NewZeroCopyReader(s12)
+	rh12 := protocol.RequestHeader{}
+	err12 := ReadHeader(&rh12, zr12)
+	assert.NotNil(t, err12)
+
+	// Invalid header key with space — must be rejected
+	s13 := "POST / HTTP/1.1\r\nHost: example.com\r\nBad Key: value\r\n\r\n"
+	zr13 := mock.NewZeroCopyReader(s13)
+	rh13 := protocol.RequestHeader{}
+	err13 := ReadHeader(&rh13, zr13)
+	assert.NotNil(t, err13)
+
+	// Invalid header value with invalid char — must be rejected
+	s14 := "POST / HTTP/1.1\r\nHost: example.com\r\nX-Test: val\x00ue\r\n\r\n"
+	zr14 := mock.NewZeroCopyReader(s14)
+	rh14 := protocol.RequestHeader{}
+	err14 := ReadHeader(&rh14, zr14)
+	assert.NotNil(t, err14)
 }
 
 func TestRequestHeaderSetGet(t *testing.T) {

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -81,18 +81,14 @@ func TestRequestHeader_Read(t *testing.T) {
 	assert.DeepEqual(t, []byte("100-continue"), rh.Peek("Expect"))
 }
 
-func TestRequestHeader_Peek(t *testing.T) {
-	// Requests with both Content-Length and Transfer-Encoding must be rejected
-	// to prevent HTTP request smuggling. See RFC 9112 Section 6.3.
-	s := "PUT /foo/bar HTTP/1.1\r\nExpect: 100-continue\r\nUser-Agent: foo\r\nHost: 127.0.0.1\r\nConnection: Keep-Alive\r\nContent-Length: 5\r\nTransfer-Encoding: foo\r\nContent-Type: foo/bar\r\n\r\nabcdef4343"
-	zr := mock.NewZeroCopyReader(s)
-	rh := protocol.RequestHeader{}
-	err := ReadHeader(&rh, zr)
-	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "Transfer-Encoding") || strings.Contains(err.Error(), "Content-Length"))
-}
-
 func TestRequestHeader_SmugglingRejected(t *testing.T) {
+	// CL + non-standard TE — must be rejected
+	s0 := "PUT /foo/bar HTTP/1.1\r\nExpect: 100-continue\r\nUser-Agent: foo\r\nHost: 127.0.0.1\r\nConnection: Keep-Alive\r\nContent-Length: 5\r\nTransfer-Encoding: foo\r\nContent-Type: foo/bar\r\n\r\nabcdef4343"
+	zr0 := mock.NewZeroCopyReader(s0)
+	rh0 := protocol.RequestHeader{}
+	err0 := ReadHeader(&rh0, zr0)
+	assert.NotNil(t, err0)
+
 	// CL then TE: chunked — must be rejected
 	s := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nTransfer-Encoding: chunked\r\n\r\n"
 	zr := mock.NewZeroCopyReader(s)

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -90,11 +90,11 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	assert.NotNil(t, err0)
 
 	// CL then TE: chunked — must be rejected
-	s := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nTransfer-Encoding: chunked\r\n\r\n"
-	zr := mock.NewZeroCopyReader(s)
-	rh := protocol.RequestHeader{}
-	err := ReadHeader(&rh, zr)
-	assert.NotNil(t, err)
+	s1 := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nTransfer-Encoding: chunked\r\n\r\n"
+	zr1 := mock.NewZeroCopyReader(s1)
+	rh1 := protocol.RequestHeader{}
+	err1 := ReadHeader(&rh1, zr1)
+	assert.NotNil(t, err1)
 
 	// TE: chunked then CL — must also be rejected
 	s2 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\nContent-Length: 10\r\n\r\n"

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -194,6 +194,16 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	rh14 := protocol.RequestHeader{}
 	err14 := ReadHeader(&rh14, zr14)
 	assert.NotNil(t, err14)
+
+	// Multiple TE header lines (e.g. "TE: gzip" then "TE: chunked") — strictly rejected.
+	// Although RFC 9112 treats multiple header lines as a comma-separated list,
+	// we intentionally reject this to prevent smuggling via inconsistent header merging
+	// across proxies and backends.
+	s15 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n\r\n"
+	zr15 := mock.NewZeroCopyReader(s15)
+	rh15 := protocol.RequestHeader{}
+	err15 := ReadHeader(&rh15, zr15)
+	assert.NotNil(t, err15)
 }
 
 func TestRequestHeaderSetGet(t *testing.T) {

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -160,22 +160,21 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	err8 := ReadHeader(&rh8, zr8)
 	assert.NotNil(t, err8)
 
-	// TE: identity alone — accepted for backward compatibility (identity = no encoding)
+	// TE: identity alone — rejected (removed in RFC 7230 and RFC 9112 Section 11.2)
 	s9 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: identity\r\n\r\n"
 	zr9 := mock.NewZeroCopyReader(s9)
 	rh9 := protocol.RequestHeader{}
 	err9 := ReadHeader(&rh9, zr9)
-	assert.Nil(t, err9)
+	assert.NotNil(t, err9)
 
-	// TE: gzip, chunked (chunked is final) — must be accepted
+	// TE: gzip, chunked — rejected (only pure "chunked" accepted, like Go net/http and nginx)
 	s10 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n"
 	zr10 := mock.NewZeroCopyReader(s10)
 	rh10 := protocol.RequestHeader{}
 	err10 := ReadHeader(&rh10, zr10)
-	assert.Nil(t, err10)
-	assert.DeepEqual(t, -1, rh10.ContentLength())
+	assert.NotNil(t, err10)
 
-	// TE: chunked, gzip (chunked is not final) — must be rejected (RFC 9112 Section 6.3 Rule 4)
+	// TE: chunked, gzip — must be rejected
 	s11 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked, gzip\r\n\r\n"
 	zr11 := mock.NewZeroCopyReader(s11)
 	rh11 := protocol.RequestHeader{}
@@ -213,13 +212,41 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	err15 := ReadHeader(&rh15, zr15)
 	assert.NotNil(t, err15)
 
-	// TE with trailing spaces and mixed case — chunked is final, must be accepted
-	s16 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: gzip, Chunked \t\r\n\r\n"
+	// Multiple TE: chunked + identity — strictly rejected (proxy may take last TE as identity)
+	s16 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: identity\r\n\r\n"
 	zr16 := mock.NewZeroCopyReader(s16)
 	rh16 := protocol.RequestHeader{}
 	err16 := ReadHeader(&rh16, zr16)
-	assert.Nil(t, err16)
-	assert.DeepEqual(t, -1, rh16.ContentLength())
+	assert.NotNil(t, err16)
+
+	// Multiple TE: identity + chunked — strictly rejected
+	s17 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: identity\r\nTransfer-Encoding: chunked\r\n\r\n"
+	zr17 := mock.NewZeroCopyReader(s17)
+	rh17 := protocol.RequestHeader{}
+	err17 := ReadHeader(&rh17, zr17)
+	assert.NotNil(t, err17)
+
+	// Duplicate TE: chunked + chunked — strictly rejected
+	s18 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked\r\nTransfer-Encoding: chunked\r\n\r\n"
+	zr18 := mock.NewZeroCopyReader(s18)
+	rh18 := protocol.RequestHeader{}
+	err18 := ReadHeader(&rh18, zr18)
+	assert.NotNil(t, err18)
+
+	// Duplicate TE: identity + identity — strictly rejected
+	s19 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: identity\r\nTransfer-Encoding: identity\r\n\r\n"
+	zr19 := mock.NewZeroCopyReader(s19)
+	rh19 := protocol.RequestHeader{}
+	err19 := ReadHeader(&rh19, zr19)
+	assert.NotNil(t, err19)
+
+	// TE: Chunked with mixed case — must be accepted (case-insensitive match)
+	s20 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: Chunked\r\n\r\n"
+	zr20 := mock.NewZeroCopyReader(s20)
+	rh20 := protocol.RequestHeader{}
+	err20 := ReadHeader(&rh20, zr20)
+	assert.Nil(t, err20)
+	assert.DeepEqual(t, -1, rh20.ContentLength())
 }
 
 func TestRequestHeaderSetGet(t *testing.T) {

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -137,6 +137,42 @@ func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	err6 := ReadHeader(&rh6, zr6)
 	assert.Nil(t, err6)
 	assert.DeepEqual(t, 5, rh6.ContentLength())
+
+	// CL then TE: identity — must be rejected (RFC 9112 Section 6.3 Rule 3)
+	s7 := "POST / HTTP/1.1\r\nHost: example.com\r\nContent-Length: 10\r\nTransfer-Encoding: identity\r\n\r\n"
+	zr7 := mock.NewZeroCopyReader(s7)
+	rh7 := protocol.RequestHeader{}
+	err7 := ReadHeader(&rh7, zr7)
+	assert.NotNil(t, err7)
+
+	// TE: identity then CL — must also be rejected
+	s8 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: identity\r\nContent-Length: 10\r\n\r\n"
+	zr8 := mock.NewZeroCopyReader(s8)
+	rh8 := protocol.RequestHeader{}
+	err8 := ReadHeader(&rh8, zr8)
+	assert.NotNil(t, err8)
+
+	// TE: identity alone — accepted for backward compatibility (identity = no encoding)
+	s9 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: identity\r\n\r\n"
+	zr9 := mock.NewZeroCopyReader(s9)
+	rh9 := protocol.RequestHeader{}
+	err9 := ReadHeader(&rh9, zr9)
+	assert.Nil(t, err9)
+
+	// TE: gzip, chunked (chunked is final) — must be accepted
+	s10 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: gzip, chunked\r\n\r\n"
+	zr10 := mock.NewZeroCopyReader(s10)
+	rh10 := protocol.RequestHeader{}
+	err10 := ReadHeader(&rh10, zr10)
+	assert.Nil(t, err10)
+	assert.DeepEqual(t, -1, rh10.ContentLength())
+
+	// TE: chunked, gzip (chunked is not final) — must be rejected (RFC 9112 Section 6.3 Rule 4)
+	s11 := "POST / HTTP/1.1\r\nHost: example.com\r\nTransfer-Encoding: chunked, gzip\r\n\r\n"
+	zr11 := mock.NewZeroCopyReader(s11)
+	rh11 := protocol.RequestHeader{}
+	err11 := ReadHeader(&rh11, zr11)
+	assert.NotNil(t, err11)
 }
 
 func TestRequestHeaderSetGet(t *testing.T) {

--- a/pkg/protocol/http1/req/header_test.go
+++ b/pkg/protocol/http1/req/header_test.go
@@ -81,6 +81,18 @@ func TestRequestHeader_Read(t *testing.T) {
 	assert.DeepEqual(t, []byte("100-continue"), rh.Peek("Expect"))
 }
 
+func TestRequestHeader_Peek(t *testing.T) {
+	s := "PUT /foo/bar HTTP/1.1\r\nExpect: 100-continue\r\nUser-Agent: foo\r\nHost: 127.0.0.1\r\nConnection: Keep-Alive\r\nContent-Length: 5\r\nContent-Type: foo/bar\r\n\r\nabcde"
+	zr := mock.NewZeroCopyReader(s)
+	rh := protocol.RequestHeader{}
+	ReadHeader(&rh, zr)
+	assert.DeepEqual(t, []byte("100-continue"), rh.Peek("Expect"))
+	assert.DeepEqual(t, []byte("127.0.0.1"), rh.Peek("Host"))
+	assert.DeepEqual(t, []byte("foo"), rh.Peek("User-Agent"))
+	assert.DeepEqual(t, []byte("Keep-Alive"), rh.Peek("Connection"))
+	assert.DeepEqual(t, []byte("foo/bar"), rh.Peek("Content-Type"))
+}
+
 func TestRequestHeader_SmugglingRejected(t *testing.T) {
 	// CL + non-standard TE — must be rejected
 	s0 := "PUT /foo/bar HTTP/1.1\r\nExpect: 100-continue\r\nUser-Agent: foo\r\nHost: 127.0.0.1\r\nConnection: Keep-Alive\r\nContent-Length: 5\r\nTransfer-Encoding: foo\r\nContent-Type: foo/bar\r\n\r\nabcdef4343"


### PR DESCRIPTION
## Summary

  Hardens HTTP/1.1 request header parsing to prevent HTTP request smuggling attacks. Aligned with **RFC 9112** and **Go net/http** / **nginx** behavior.

 **Breaking Change**: previously accepted requests may now be rejected with 400.

  ## What changed

  ### 1. Reject Transfer-Encoding + Content-Length co-existence (RFC 9112 §6.3 Rule 3)

  Rejects requests containing both headers in **any order**, returning `errBothTEAndCL`. Unlike Go net/http (which silently strips CL), we reject outright — this prevents CL.TE smuggling even when a front proxy doesn't understand TE.

  ### 2. Only accept `Transfer-Encoding: chunked` (like Go net/http and nginx)

  - `Transfer-Encoding: identity` → **rejected** (removed in RFC 7230 / RFC 9112 §11.2; Go dropped support since 1.15)
  - `Transfer-Encoding: gzip, chunked` → **rejected** (multi-coding values are not used in practice but can cause proxy parsing inconsistencies)
  - Multiple `Transfer-Encoding` header lines → **rejected** with `errMultipleTE` (proxies merge multi-line headers inconsistently)
  - Only pure `Transfer-Encoding: chunked` (case-insensitive) is accepted

  ### 3. Reject duplicate Content-Length with conflicting values (RFC 9112 §6.3 Rule 5)

  - `Content-Length: 10` + `Content-Length: 20` → **rejected** with `errDuplicateCL`
  - `Content-Length: 10` + `Content-Length: 10` → accepted (identical values are safe)

  ## Error types

  | Error | Trigger |
  |---|---|
  | `errBothTEAndCL` | TE + CL co-exist in any order |
  | `errDuplicateCL` | Multiple CL headers with different values |
  | `errUnsupportedTE` | TE value is not "chunked" |
  | `errMultipleTE` | More than one TE header line |

  ## Attack vectors mitigated

  - **CL.TE smuggling**: front proxy uses CL, backend uses TE → rejected at backend
  - **TE.CL smuggling**: front proxy uses TE, backend uses CL → rejected at backend
  - **TE obfuscation**: `identity`, `gzip, chunked`, multi-line TE, mixed-case tricks → all normalized or rejected

## Comparison with Go net/http

  | Behavior | Go net/http | This PR |
  |---|---|---|
  | TE + CL co-exist | Silent strip CL, accept | **Reject with 400** (more secure) |
  | `TE: identity` | Reject (since Go 1.15) | Reject |
  | `TE: gzip, chunked` | Reject | Reject |
  | Multiple TE lines | Reject | Reject |
  | Duplicate CL (same) | Deduplicate | Accept |
  | Duplicate CL (diff) | Reject | Reject |