### PR TITLE
fix(hz): handler duplicate check for receiver methods

### DIFF
--- a/cmd/hz/generator/handler.go
+++ b/cmd/hz/generator/handler.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/cloudwego/hertz/cmd/hz/generator/model"
@@ -233,7 +234,9 @@ func (pkgGen *HttpPackageGenerator) updateHandler(handler interface{}, handlerTp
 
 	// insert new handler
 	for _, method := range handler.(Handler).Methods {
-		if bytes.Contains(file, []byte(fmt.Sprintf("func %s(", method.Name))) {
+		// match both plain functions "func Name(" and receiver methods "func (x Type) Name("
+		re := regexp.MustCompile(fmt.Sprintf(`func\s+(\([^)]*\)\s+)?%s\s*\(`, regexp.QuoteMeta(method.Name)))
+		if re.Match(file) {
 			continue
 		}
 

--- a/cmd/hz/generator/handler_test.go
+++ b/cmd/hz/generator/handler_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generator
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+)
+
+func TestHandlerMethodExistsMatch(t *testing.T) {
+	methodName := "CreateUser"
+	re := regexp.MustCompile(fmt.Sprintf(`func\s+(\([^)]*\)\s+)?%s\s*\(`, regexp.QuoteMeta(methodName)))
+
+	tests := []struct {
+		name  string
+		file  string
+		match bool
+	}{
+		{
+			name:  "plain function",
+			file:  `func CreateUser(ctx context.Context, c *app.RequestContext) {`,
+			match: true,
+		},
+		{
+			name:  "receiver method pointer",
+			file:  `func (handler *APIHandler) CreateUser(ctx context.Context, c *app.RequestContext) {`,
+			match: true,
+		},
+		{
+			name:  "receiver method value",
+			file:  `func (h APIHandler) CreateUser(ctx context.Context, c *app.RequestContext) {`,
+			match: true,
+		},
+		{
+			name:  "different method",
+			file:  `func CreateRole(ctx context.Context, c *app.RequestContext) {`,
+			match: false,
+		},
+		{
+			name:  "prefix mismatch",
+			file:  `func CreateUserV2(ctx context.Context, c *app.RequestContext) {`,
+			match: false,
+		},
+		{
+			name:  "in comment",
+			file:  `// func CreateUser is deprecated`,
+			match: false,
+		},
+		{
+			name:  "multiline file with receiver",
+			file:  "package handler\n\nfunc (s *Service) CreateUser(ctx context.Context) {\n}\n",
+			match: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := re.Match([]byte(tt.file))
+			if got != tt.match {
+				t.Errorf("match = %v, want %v for input: %s", got, tt.match, tt.file)
+			}
+		})
+	}
+}

--- a/cmd/hz/test_hz_unix.sh
+++ b/cmd/hz/test_hz_unix.sh
@@ -26,16 +26,18 @@ install_dependent_tools() {
   # install thriftgo
   go install github.com/cloudwego/thriftgo@latest
 
-  # install protoc
-  wget https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
-  unzip -d protoc-3.19.4-linux-x86_64 protoc-3.19.4-linux-x86_64.zip
-  cp protoc-3.19.4-linux-x86_64/bin/protoc $PATH_BIN
-  cp -r protoc-3.19.4-linux-x86_64/include/google $PATH_BIN
+  # install protoc if not already downloaded
+  if [ ! -f "$PATH_BIN/protoc" ]; then
+    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
+    unzip -d protoc-3.19.4-linux-x86_64 protoc-3.19.4-linux-x86_64.zip
+    cp protoc-3.19.4-linux-x86_64/bin/protoc $PATH_BIN
+    cp -r protoc-3.19.4-linux-x86_64/include/google $PATH_BIN
+  fi
 }
 
 go_tidy_build() {
   # make sure we get the latest version for testing
-  go get github.com/cloudwego/hertz@develop
+  go get github.com/cloudwego/hertz@main
   go mod tidy && go build .
 }
 

--- a/cmd/hz/test_hz_windows.sh
+++ b/cmd/hz/test_hz_windows.sh
@@ -23,7 +23,7 @@ install_dependent_tools() {
 
 go_tidy_build() {
   # make sure we get the latest version for testing
-  go get github.com/cloudwego/hertz@develop
+  go get github.com/cloudwego/hertz@main
   go mod tidy && go build .
 }
 


### PR DESCRIPTION
Fixes #1488 

The duplicate-handler check in updateHandler used a plain substring match ("func MethodName(") which missed receiver-style methods from custom templates (e.g., "func (h *Handler) MethodName("). This caused hz update to regenerate all existing handlers, producing "method already declared" errors. Use a regex that matches both plain functions and receiver methods.

Also fix test scripts to use `@main` instead of `@develop`, which was broken since the develop branch was deprecated. Skip protoc download if already present so the script works when run locally repeatedly.