### PR TITLE
docs(hz): add README, clarifying comments, and fix broken tests

### DIFF
--- a/cmd/hz/.gitignore
+++ b/cmd/hz/.gitignore
@@ -1,0 +1,10 @@
+# Generated output from generate.sh
+generate_out/
+
+# Generated test output from model_test.go
+generator/testdata/
+
+# Build artifacts from test scripts
+.local/
+hz
+protoc-*

--- a/cmd/hz/DESIGN.md
+++ b/cmd/hz/DESIGN.md
@@ -1,0 +1,87 @@
+# hz Internal Design
+
+This document describes the internal architecture of `hz` for contributors and maintainers. For usage, see [README.md](README.md).
+
+## Dual-Mode Execution
+
+`hz` runs in two distinct modes:
+
+1. **CLI Mode** (normal): Parses arguments, generates project layout, then invokes the IDL compiler (thriftgo/protoc) as a subprocess.
+2. **Plugin Mode**: When invoked *by* the IDL compiler as a plugin (`thrift-gen-hertz` or `protoc-gen-hertz`), it reads the parsed AST from stdin and generates Hertz-specific code.
+
+This means a single `hz new` command actually runs `hz` twice:
+```
+User -> hz (CLI mode) -> thriftgo/protoc -> hz (Plugin mode) -> generated code
+```
+
+The plugin mode is detected via the `HERTZ_PLUGIN_MODE` environment variable, set by the CLI before invoking the compiler.
+
+## Package Structure
+
+```
+cmd/hz/
+├── app/          # CLI commands (new/update/model/client) and plugin triggering
+├── config/       # Argument parsing, validation, and compiler command construction
+├── generator/    # Code generation engine (handlers, routers, models, clients, templates)
+│   └── model/    # IDL-to-Go type system and Go code backend
+├── thrift/       # Thrift IDL plugin: AST conversion, type resolution, annotation extraction
+├── protobuf/     # Protobuf IDL plugin (parallel structure to thrift/)
+├── meta/         # Constants, version info, and `.hz` manifest management
+└── util/         # Shared utilities (string ops, file helpers, env detection, logging)
+```
+
+## Code Generation Pipeline
+
+### 1. Layout Generation (`new` command only)
+
+Creates the project skeleton:
+- `main.go` with Hertz server bootstrap
+- `go.mod` with required dependencies
+- `router.go` with route registration entry point
+- Directory structure: `biz/handler/`, `biz/model/`, `biz/router/`
+
+### 2. Plugin Execution
+
+The IDL compiler parses the `.thrift`/`.proto` file and passes the AST to `hz` running in plugin mode. The plugin:
+
+1. **Converts** the IDL AST into internal `Service` and `HttpMethod` structs, extracting HTTP annotations (paths, methods, serializers)
+2. **Resolves** type references across IDL files into Go import paths
+3. **Generates** code via the `HttpPackageGenerator`
+
+### 3. Handler Generation
+
+Two modes controlled by `--handler_by_method`:
+
+- **By service** (default): All handlers for a service go into one file (e.g., `user_service.go`). On `update`, new methods are appended using the `handler_single.go` template.
+- **By method**: Each handler gets its own file (e.g., `create_user.go`). On `update`, new files are created but existing ones are never modified.
+
+### 4. Router Generation
+
+Routes are organized as a tree (`RouterNode`), built by inserting each method's HTTP path. The tree is then:
+
+1. Traversed to assign unique middleware group names (`DyeGroupName`)
+2. Rendered into Go route registration code with `r.Group()`/`r.GET()`/etc.
+3. Middleware stubs are generated for each route group
+
+### 5. Template System
+
+All generated code is rendered from Go templates. Templates support:
+
+- **Custom delimiters**: Override `{{ }}` if your template contains Go template syntax
+- **Update behaviors**: `skip` (don't touch existing), `cover` (regenerate), `append` (add new content)
+- **Loop modes**: Generate one file per service (`loop_service`) or per method (`loop_method`)
+- **Custom templates**: Override any default template via `--customize_package`
+
+## Manifest File (`.hz`)
+
+The `.hz` YAML file in the project root tracks:
+- hz version used to generate the project
+- Handler, model, and router directory paths
+
+This allows `hz update` to locate existing generated code without requiring the user to re-specify all flags.
+
+## Argument Passing Between CLI and Plugin
+
+Since the plugin runs as a child process of the IDL compiler (not `hz` directly), CLI arguments are serialized into a comma-separated string via reflection (`util.PackArgs`) and passed through compiler plugin options. The plugin deserializes them back with `util.UnpackArgs`.
+
+Format: `FieldName=value,SliceField=val1;val2;val3,MapField=k1=v1;k2=v2`

--- a/cmd/hz/README.md
+++ b/cmd/hz/README.md
@@ -1,0 +1,160 @@
+# hz - Hertz Code Generator
+
+`hz` is the official code generation tool for the [Hertz](https://github.com/cloudwego/hertz) HTTP framework. It parses IDL (Interface Definition Language) files — Thrift or Protobuf — and generates a complete, scaffolded Hertz project including handlers, routers, models, and client code.
+
+## Quick Start
+
+```bash
+# Build
+cd cmd/hz && go build -o hz .
+
+# Generate a new project from Thrift IDL
+hz new --idl api.thrift --module github.com/example/myservice
+
+# Generate a new project from Protobuf IDL
+hz new --idl api.proto --module github.com/example/myservice
+
+# Update an existing project after IDL changes (module read from go.mod)
+hz update --idl api.thrift
+
+# Generate model code only (module read from go.mod)
+hz model --idl api.thrift
+
+# Generate client code (module read from go.mod)
+hz client --idl api.thrift --base_domain localhost:8888
+```
+
+## Commands
+
+| Command  | Description |
+|----------|-------------|
+| `new`    | Scaffold a new Hertz project from IDL, generating layout, handlers, routers, and models |
+| `update` | Incrementally add new handlers/routes for newly added IDL methods without overwriting existing code |
+| `model`  | Generate only Go struct definitions (models) from IDL types |
+| `client` | Generate Hertz HTTP client code from IDL service definitions |
+
+## Flags
+
+### Global
+
+| Flag | Description |
+|------|-------------|
+| `--verbose`, `-vv` | Turn on verbose (debug-level) logging |
+
+### Project Structure
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--idl` | all | IDL file path (`.thrift` or `.proto`) |
+| `--module`, `--mod` | all | Go module name (auto-detected from `go.mod` if present) |
+| `--service` | `new` | Service name (default: `hertz_service`) |
+| `--out_dir` | `new`, `update`, `model` | Project output directory (default: current directory) |
+| `--handler_dir` | `new`, `update` | Handler directory relative to `out_dir` (default: `biz/handler`) |
+| `--model_dir` | all | Model directory relative to `out_dir` (default: `biz/model`) |
+| `--router_dir` | `new` | Router directory relative to `out_dir` (default: `biz/router`) |
+| `--client_dir` | `new`, `update`, `client` | Client output directory. For `new`/`update`: no client code if omitted. For `client`: defaults to IDL-derived path |
+| `--force_client_dir` | `client` | Client output directory without IDL namespace subdirectories |
+| `--use` | `new`, `update`, `client` | Import models from an external package instead of generating them |
+
+### Code Generation
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--handler_by_method` | `new`, `update` | Generate a separate handler file per method (default: one file per service) |
+| `--sort_router` | `new`, `update` | Sort router registration code for deterministic output |
+| `--no_recurse` | all | Generate only the master IDL model, skip included/imported dependencies |
+| `--force`, `-f` | `new` | Force overwrite an existing project |
+| `--force_client` | `client` | Force regenerate `hertz_client.go` even if it already exists |
+| `--base_domain` | `client` | Default request domain for generated client code |
+| `--enable_extends` | `new`, `update`, `client` | Parse `extends` keyword in Thrift IDL |
+
+### Struct Tags
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--snake_tag` | all | Use snake_case for `form`, `query`, and `json` tags |
+| `--json_enumstr` | all | Use string values instead of numbers for JSON enum fields (Thrift only) |
+| `--unset_omitempty` | all | Remove `omitempty` from generated struct tags |
+| `--pb_camel_json_tag` | all | Use camelCase for JSON tags (Protobuf only) |
+| `--rm_tag` | all | Remove a default tag (e.g. `--rm_tag json`). Explicitly annotated tags are kept |
+| `--query_enumint` | `client` | Use numeric values for enum query parameters in client code |
+| `--enable_optional` | `client` | Omit optional Thrift fields from query if not set |
+
+### IDL Compiler Options
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--proto_path`, `-I` | all | Add an include search path for Protobuf imports |
+| `--thriftgo`, `-t` | all | Pass-through arguments to thriftgo (e.g. `-t naming_style=golint`) |
+| `--protoc`, `-p` | all | Pass-through arguments to protoc |
+| `--thrift-plugins` | `new`, `update`, `client` | Additional thriftgo plugins (`{name}:{options}`) |
+| `--protoc-plugins` | `new`, `update`, `client` | Additional protoc plugins (`{name}:{options}:{out_dir}`) |
+| `--option_package`, `-P` | `new`, `update` | Map IDL include path to Go import path (`{include}={import}`) |
+| `--trim_gopackage`, `--trim_pkg` | all | Trim prefix from protobuf `go_package` to avoid deeply nested directories |
+
+### Template Customization
+
+| Flag | Commands | Description |
+|------|----------|-------------|
+| `--customize_layout` | `new` | Path to custom layout template YAML |
+| `--customize_layout_data_path` | `new` | Path to JSON data file for rendering layout templates |
+| `--customize_package` | `new`, `update`, `client` | Path to custom package template YAML (overrides handler/router/middleware templates) |
+| `--exclude_file`, `-E` | all | Exclude a file path from being generated/updated |
+
+## Custom Templates
+
+Create a YAML config file and pass it with `--customize_package`:
+
+```yaml
+layouts:
+  - path: biz/handler/handler.go        # overrides default handler template
+    delims: ["{{", "}}"]
+    body: |
+      package {{.PackageName}}
+      // your custom handler template...
+
+  - path: biz/custom/{{.ServiceName}}.go  # new file, path supports templates
+    delims: ["{{", "}}"]
+    loop_service: true                     # generate one file per service
+    update_behavior:
+      type: append                         # on update: skip/cover/append
+      append_key: method                   # append by method or service
+      append_content_tpl: |
+        // new method: {{.Name}}
+    body: |
+      package custom
+      // your template...
+```
+
+Template update behaviors:
+- `skip` — do not modify existing file
+- `cover` — overwrite existing file completely
+- `append` — append new content (e.g. new handler methods) to existing file
+
+## Example Output
+
+Run `generate.sh` to see what hz generates for the test IDL files:
+
+```bash
+cd cmd/hz
+
+# Generate examples for all IDL types (output in generate_out/)
+./generate.sh
+
+# Generate specific targets only
+./generate.sh thrift proto3
+
+# CI mode: generate, verify the output compiles, then clean up
+./generate.sh --verify --clean
+```
+
+Targets: `thrift`, `proto2`, `proto3`, `handler_by_method`.
+
+## Dependencies
+
+- [thriftgo](https://github.com/cloudwego/thriftgo) — Thrift compiler (auto-installed if missing)
+- [protoc](https://github.com/protocolbuffers/protobuf) — Protobuf compiler (must be installed manually)
+
+## Architecture
+
+See [DESIGN.md](DESIGN.md) for internal architecture, the dual-mode execution model, and the code generation pipeline.

--- a/cmd/hz/app/app.go
+++ b/cmd/hz/app/app.go
@@ -33,7 +33,8 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// global args. MUST fork it when use
+// globalArgs is the shared argument template populated by CLI flag bindings.
+// Each command must call Fork() via Parse() before use to avoid mutation across commands.
 var globalArgs = config.NewArgument()
 
 func New(c *cli.Context) error {
@@ -139,6 +140,9 @@ func Client(c *cli.Context) error {
 	return nil
 }
 
+// PluginMode checks if the current process was invoked as a protoc/thriftgo plugin
+// (detected via EnvPluginMode env var). If so, it runs the plugin and exits.
+// This is called before CLI parsing in main() to handle the plugin re-entry path.
 func PluginMode() {
 	mode := os.Getenv(meta.EnvPluginMode)
 	if len(os.Args) <= 1 && mode != "" {
@@ -414,6 +418,8 @@ func GenerateLayout(args *config.Argument) error {
 	return nil
 }
 
+// TriggerPlugin invokes the IDL compiler (protoc/thriftgo) with hz registered as a plugin.
+// The compiler parses the IDL and calls back into hz (via PluginMode) to generate code.
 func TriggerPlugin(args *config.Argument) error {
 	if len(args.IdlPaths) == 0 {
 		return nil

--- a/cmd/hz/config/argument.go
+++ b/cmd/hz/config/argument.go
@@ -278,6 +278,8 @@ func (arg *Argument) checkPackage() error {
 	return nil
 }
 
+// Pack serializes the argument to a string list for passing through the
+// protoc/thriftgo plugin interface (see util.PackArgs).
 func (arg *Argument) Pack() ([]string, error) {
 	data, err := util.PackArgs(arg)
 	if err != nil {
@@ -294,7 +296,8 @@ func (arg *Argument) Unpack(data []string) error {
 	return nil
 }
 
-// Fork can copy its own parameters to a new argument
+// Fork creates a deep copy of the argument. This is necessary because globalArgs
+// is shared across CLI commands and its slice/map fields would otherwise be mutated.
 func (arg *Argument) Fork() *Argument {
 	args := NewArgument()
 	*args = *arg
@@ -326,6 +329,8 @@ func IdlTypeToCompiler(idlType string) (string, error) {
 	}
 }
 
+// ModelPackagePrefix returns the Go import path prefix for generated model packages.
+// This is passed to thriftgo so it generates import paths matching our output structure.
 func (arg *Argument) ModelPackagePrefix() (string, error) {
 	ret := arg.Gomod
 	if arg.ModelDir == "" {

--- a/cmd/hz/config/cmd.go
+++ b/cmd/hz/config/cmd.go
@@ -87,6 +87,9 @@ func link(src, dst string) error {
 	return nil
 }
 
+// BuildPluginCmd constructs the protoc/thriftgo command that invokes the current hz binary
+// as a plugin. The hz binary re-enters as a plugin via PluginMode() (detected by EnvPluginMode).
+// Arguments are serialized via PackArgs and passed as comma-separated key=value pairs.
 func BuildPluginCmd(args *Argument) (*exec.Cmd, error) {
 	exe, err := os.Executable()
 	if err != nil {
@@ -172,6 +175,9 @@ func BuildPluginCmd(args *Argument) (*exec.Cmd, error) {
 	return cmd, nil
 }
 
+// GetThriftgoOptions builds the thriftgo "-g go:..." option string.
+// It starts with default options (reserve_comments, no auto json tags) and appends
+// user-specified options plus the computed package prefix.
 func (arg *Argument) GetThriftgoOptions() (string, error) {
 	defaultOpt := "reserve_comments,gen_json_tag=false,"
 	prefix, err := arg.ModelPackagePrefix()

--- a/cmd/hz/generate.sh
+++ b/cmd/hz/generate.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Generates hz example/test output using the test IDL files.
+#
+# Usage:
+#   ./generate.sh [OPTIONS] [TARGETS...]
+#
+# Targets: thrift, proto2, proto3, handler_by_method (default: all)
+#
+# Options:
+#   --verify   Run "go mod tidy && go build" to verify generated code compiles
+#   --clean    Remove output after verification (for CI)
+#   --hz PATH  Path to hz binary (default: builds from source)
+#
+# Examples:
+#   ./generate.sh                        # generate all examples to examples/output/
+#   ./generate.sh thrift proto3           # generate specific targets
+#   ./generate.sh --verify --clean        # CI mode: generate, build, cleanup
+
+set -e
+
+HZ_DIR="$(cd "$(dirname "$0")" && pwd)"
+OUTPUT_DIR="$HZ_DIR/generate_out"
+MODULE="github.com/cloudwego/hertz/cmd/hz/test"
+
+THRIFT_IDL="$HZ_DIR/testdata/thrift/psm.thrift"
+PROTO2_IDL="$HZ_DIR/testdata/protobuf2/psm/psm.proto"
+PROTO2_SEARCH="$HZ_DIR/testdata/protobuf2"
+PROTO3_IDL="$HZ_DIR/testdata/protobuf3/psm/psm.proto"
+PROTO3_SEARCH="$HZ_DIR/testdata/protobuf3"
+# Locate protoc's well-known types include dir.
+# Search: relative to protoc binary, then common system paths.
+PROTO_SYSTEM=""
+for _dir in \
+  "$(cd "$(dirname "$(command -v protoc 2>/dev/null)")/.." 2>/dev/null && pwd)/include" \
+  "/usr/include" \
+  "/usr/local/include" \
+  "$HZ_DIR/.local/include"; do
+  if [ -d "$_dir/google/protobuf" ] 2>/dev/null; then
+    PROTO_SYSTEM="$_dir"
+    break
+  fi
+done
+
+HZ=""
+VERIFY=false
+CLEAN=false
+TARGETS=()
+
+# parse args
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --verify) VERIFY=true; shift ;;
+    --clean)  CLEAN=true; shift ;;
+    --hz)     HZ="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"; shift 2 ;;
+    -*)       echo "unknown option: $1" >&2; exit 1 ;;
+    *)        TARGETS+=("$1"); shift ;;
+  esac
+done
+
+# default: all targets
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=(thrift proto2 proto3 handler_by_method)
+fi
+
+# build hz if not provided
+if [[ -z "$HZ" ]]; then
+  echo "==> Building hz..."
+  cd "$HZ_DIR"
+  go build -o hz .
+  HZ="$HZ_DIR/hz"
+fi
+
+cleanup() { cd "$HZ_DIR"; }
+trap cleanup EXIT
+
+# run_target NAME NEW_ARGS...
+# Runs: hz new, hz update, hz model, hz client in a subdirectory.
+run_target() {
+  local name="$1"; shift
+  local dir="$OUTPUT_DIR/$name"
+
+  echo "==> $name: new..."
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  cd "$dir"
+  "$HZ" new --mod="$MODULE" -f "$@"
+
+  if $VERIFY; then
+    echo "  build..."
+    go get github.com/cloudwego/hertz@main
+    go mod tidy && go build .
+  fi
+
+  echo "  update..."
+  "$HZ" update "$@"
+  echo "  model..."
+  "$HZ" model "$@"
+  echo "  client..."
+  "$HZ" client "$@" --client_dir=hertz_client
+
+  if $CLEAN; then
+    rm -rf "$dir"
+  fi
+}
+
+for target in "${TARGETS[@]}"; do
+  case "$target" in
+    thrift)
+      run_target thrift --idl="$THRIFT_IDL"
+      ;;
+    proto2)
+      run_target proto2 ${PROTO_SYSTEM:+-I="$PROTO_SYSTEM"} -I="$PROTO2_SEARCH" --idl="$PROTO2_IDL"
+      ;;
+    proto3)
+      run_target proto3 ${PROTO_SYSTEM:+-I="$PROTO_SYSTEM"} -I="$PROTO3_SEARCH" --idl="$PROTO3_IDL"
+      ;;
+    handler_by_method)
+      dir="$OUTPUT_DIR/handler_by_method"
+      echo "==> handler_by_method: new..."
+      rm -rf "$dir"
+      mkdir -p "$dir"
+      cd "$dir"
+      "$HZ" new --idl="$THRIFT_IDL" --mod="$MODULE" -f --handler_by_method
+      if $VERIFY; then
+        echo "  build..."
+        go get github.com/cloudwego/hertz@main
+        go mod tidy && go build .
+      fi
+      if $CLEAN; then rm -rf "$dir"; fi
+      ;;
+    *)
+      echo "unknown target: $target" >&2; exit 1
+      ;;
+  esac
+done
+
+if ! $CLEAN; then
+  echo ""
+  echo "Done. Generated examples in: $OUTPUT_DIR"
+  echo ""
+  echo "Directory layout:"
+  cd "$OUTPUT_DIR"
+  find . -type f -name "*.go" | sort | head -80
+fi

--- a/cmd/hz/generator/client.go
+++ b/cmd/hz/generator/client.go
@@ -25,6 +25,8 @@ import (
 	"github.com/cloudwego/hertz/cmd/hz/util"
 )
 
+// ClientMethod extends HttpMethod with generated code snippets for
+// building HTTP requests (setting body, query, path params, etc.).
 type ClientMethod struct {
 	*HttpMethod
 	BodyParamsCode   string
@@ -49,6 +51,9 @@ type ClientFile struct {
 	ClientMethods []*ClientMethod
 }
 
+// genClient generates client code for each service. It creates two files per service:
+// 1. hertz_client.go - the base HTTP client (only generated once unless ForceUpdateClient)
+// 2. <service_name>.go - service-specific client methods
 func (pkgGen *HttpPackageGenerator) genClient(pkg *HttpPackage, clientDir string) error {
 	for _, s := range pkg.Services {
 		cliDir := util.SubDir(clientDir, util.ToSnakeCase(s.Name))

--- a/cmd/hz/generator/file.go
+++ b/cmd/hz/generator/file.go
@@ -25,11 +25,12 @@ import (
 	"github.com/cloudwego/hertz/cmd/hz/util"
 )
 
+// File represents a generated output file pending write to disk.
 type File struct {
-	Path        string
-	Content     string
-	NoRepeat    bool
-	FileTplName string
+	Path        string // relative output path
+	Content     string // rendered file content
+	NoRepeat    bool   // if true, skip writing when file already exists
+	FileTplName string // source template name (used to determine update warnings)
 }
 
 // Lint is used to statically analyze and format go code

--- a/cmd/hz/generator/handler.go
+++ b/cmd/hz/generator/handler.go
@@ -30,25 +30,27 @@ import (
 	"github.com/cloudwego/hertz/cmd/hz/util/logs"
 )
 
+// HttpMethod represents a single API endpoint parsed from IDL annotations.
+// One IDL method may map to multiple HTTP methods (e.g. GET + POST), in which
+// case GenHandler is true only for the first to avoid duplicate handler functions.
 type HttpMethod struct {
 	Name               string
-	HTTPMethod         string
-	Comment            string
-	RequestTypeName    string
-	RequestTypePackage string
-	RequestTypeRawName string
-	ReturnTypeName     string
-	ReturnTypePackage  string
-	ReturnTypeRawName  string
-	Path               string
-	Serializer         string
-	OutputDir          string
-	RefPackage         string // handler import dir
-	RefPackageAlias    string // handler import alias
-	ModelPackage       map[string]string
-	GenHandler         bool // Whether to generate one handler, when an idl interface corresponds to multiple http method
-	// Annotations     map[string]string
-	Models map[string]*model.Model
+	HTTPMethod         string                  // GET, POST, PUT, DELETE, etc.
+	Comment            string                  // doc comment (formatted by InitComment)
+	RequestTypeName    string                  // Go type name for request struct
+	RequestTypePackage string                  // import path for request type
+	RequestTypeRawName string                  // original IDL name before Go conversion
+	ReturnTypeName     string                  // Go type name for response struct
+	ReturnTypePackage  string                  // import path for response type
+	ReturnTypeRawName  string                  // original IDL name before Go conversion
+	Path               string                  // HTTP route path (e.g. "/api/v1/users/:id")
+	Serializer         string                  // serialization format: JSON, Thrift, ProtoBuf
+	OutputDir          string                  // handler output subdirectory (for handler_by_method mode)
+	RefPackage         string                  // handler import path (set during router tree construction)
+	RefPackageAlias    string                  // handler import alias
+	ModelPackage       map[string]string       // model package aliases
+	GenHandler         bool                    // false to skip handler generation (dedup for multi-method IDL)
+	Models             map[string]*model.Model // all model dependencies for this method
 }
 
 type Handler struct {
@@ -71,6 +73,8 @@ type Client struct {
 	ServiceName string
 }
 
+// genHandler generates handler files and populates the router tree.
+// Two modes: HandlerByMethod creates one file per method, otherwise one file per service.
 func (pkgGen *HttpPackageGenerator) genHandler(pkg *HttpPackage, handlerDir, handlerPackage string, root *RouterNode) error {
 	for _, s := range pkg.Services {
 		var handler Handler
@@ -183,6 +187,9 @@ func (pkgGen *HttpPackageGenerator) processHandler(handler *Handler, root *Route
 	return nil
 }
 
+// updateHandler creates a new handler file or appends new methods to an existing one.
+// For existing files, it parses the Go source to insert missing imports and appends
+// handler functions that don't already exist (matched by function name regex).
 func (pkgGen *HttpPackageGenerator) updateHandler(handler interface{}, handlerTpl, filePath string, noRepeat bool) error {
 	if pkgGen.tplsInfo[handlerTpl].Disable {
 		return nil
@@ -287,6 +294,8 @@ func (pkgGen *HttpPackageGenerator) updateClient(client interface{}, clientTpl, 
 	return nil
 }
 
+// InitComment formats the method comment as a Go doc comment with @router annotation.
+// The @router tag is used by swagger-like tools to document the endpoint.
 func (m *HttpMethod) InitComment() {
 	text := strings.TrimLeft(strings.TrimSpace(m.Comment), "/")
 	if text == "" {

--- a/cmd/hz/generator/model.go
+++ b/cmd/hz/generator/model.go
@@ -30,6 +30,7 @@ import (
 
 //---------------------------------Backend----------------------------------
 
+// Option controls model code generation behavior.
 type Option string
 
 const (
@@ -37,12 +38,14 @@ const (
 	OptionTypedefAsTypeAlias Option = "TypedefAsTypeAlias"
 )
 
+// Backend abstracts the target language for model code generation.
+// Currently only Go is implemented; third-party backends are planned but not yet supported.
 type Backend interface {
 	Template() (*template.Template, error)
-	List() map[string]string
-	SetOption(opts string) error
-	GetOptions() []string
-	Funcs(name string, fn interface{}) error
+	List() map[string]string                 // returns template name -> body mapping
+	SetOption(opts string) error             // configures generation options (e.g. MarshalEnumToText)
+	GetOptions() []string                    // returns active options
+	Funcs(name string, fn interface{}) error // registers custom template functions
 }
 
 type GolangBackend struct{}
@@ -81,6 +84,9 @@ func loadThirdPartyBackend(plugin string) Backend {
 
 /**********************Generating*************************/
 
+// LoadBackend initializes the model template engine for the given backend.
+// It registers a "ROOT" template function that returns the current model being rendered,
+// allowing templates to access cross-model import information.
 func (pkgGen *HttpPackageGenerator) LoadBackend(backend meta.Backend) error {
 	bd := switchBackend(backend)
 	if bd == nil {
@@ -112,6 +118,10 @@ func (pkgGen *HttpPackageGenerator) LoadBackend(backend meta.Backend) error {
 	return nil
 }
 
+// GenModel recursively resolves model file paths and generates Go source files.
+// It first processes all imported models (dependencies), then generates the current model.
+// The gen flag controls whether to actually render the template (false for dependency-only path resolution).
+// processedModels tracks already-visited models to avoid duplicate work.
 func (pkgGen *HttpPackageGenerator) GenModel(data *model.Model, gen bool) error {
 	if pkgGen.processedModels == nil {
 		pkgGen.processedModels = map[*model.Model]bool{}

--- a/cmd/hz/generator/model/define.go
+++ b/cmd/hz/generator/model/define.go
@@ -17,9 +17,12 @@
 package model
 
 var (
+	// BaseTypes enumerates all IDL primitive types mapped to Go types.
 	BaseTypes      = []*Type{TypeBool, TypeByte, TypeInt8, TypeInt16, TypeInt32, TypeInt64, TypeUint8, TypeUint16, TypeUint32, TypeUint64, TypeFloat64, TypeString, TypeBinary}
 	ContainerTypes = []*Type{TypeBaseList, TypeBaseMap, TypeBaseSet}
-	BaseModel      = Model{}
+	// BaseModel is a sentinel Model used as Scope for builtin types.
+	// Types with Scope == &BaseModel are treated as built-in and don't need cross-package qualification.
+	BaseModel = Model{}
 )
 
 var (
@@ -28,11 +31,13 @@ var (
 		Scope: &BaseModel,
 		Kind:  KindBool,
 	}
+	// TypeByte maps Thrift's "byte" to Go's "int8" (Thrift byte is signed).
 	TypeByte = &Type{
 		Name:  "int8",
 		Scope: &BaseModel,
 		Kind:  KindInt8,
 	}
+	// TypePbByte maps Protobuf's "bytes" element to Go's "byte" (unsigned).
 	TypePbByte = &Type{
 		Name:  "byte",
 		Scope: &BaseModel,
@@ -131,6 +136,8 @@ var (
 	}
 )
 
+// NewCategoryType creates a shallow copy of typ with a different Category.
+// Used when the same Go type has different IDL semantics (e.g. int64 as enum vs constant).
 func NewCategoryType(typ *Type, cg Category) *Type {
 	cyp := *typ
 	cyp.Category = cg

--- a/cmd/hz/generator/model/expr.go
+++ b/cmd/hz/generator/model/expr.go
@@ -21,6 +21,9 @@ import (
 	"strconv"
 )
 
+// The following expression types implement the Literal interface to produce
+// Go source code for default values defined in IDL files.
+
 type BoolExpression struct {
 	Src bool
 }
@@ -41,6 +44,8 @@ func (stringExpr StringExpression) Expression() string {
 	return fmt.Sprintf("%q", stringExpr.Src)
 }
 
+// NumberExpression stores the number as a raw string to preserve the original
+// IDL representation (e.g. hex literals, large numbers).
 type NumberExpression struct {
 	Src string
 }

--- a/cmd/hz/generator/model/model.go
+++ b/cmd/hz/generator/model/model.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 )
 
+// Kind mirrors reflect.Kind to represent Go type kinds for code generation.
 type Kind uint
 
 const (
@@ -54,6 +55,8 @@ const (
 	KindUnsafePointer
 )
 
+// Category represents the IDL-level semantic type category (Thrift/Protobuf).
+// Values align with Thrift type IDs where applicable.
 type Category int64
 
 const (
@@ -70,22 +73,22 @@ const (
 	CategoryService   Category = 17
 )
 
+// Model represents a single IDL file translated into Go code generation data.
+// Each Model corresponds to one output .go file.
 type Model struct {
-	FilePath string
-	Package  string
-	Imports  map[string]*Model //{{import}}:Model
+	FilePath string            // output file path (set during generation)
+	Package  string            // Go import path for this model
+	Imports  map[string]*Model // imported models, keyed by import path
 
-	// rendering data
-	PackageName string
-	// Imports     map[string]string //{{alias}}:{{import}}
-	Typedefs  []TypeDef
-	Constants []Constant
-	Variables []Variable
-	Functions []Function
-	Enums     []Enum
-	Structs   []Struct
-	Methods   []Method
-	Oneofs    []Oneof
+	PackageName string // short package name (last segment of Package)
+	Typedefs    []TypeDef
+	Constants   []Constant
+	Variables   []Variable
+	Functions   []Function
+	Enums       []Enum
+	Structs     []Struct
+	Methods     []Method
+	Oneofs      []Oneof // protobuf oneof fields
 }
 
 func (m Model) IsEmpty() bool {
@@ -95,6 +98,7 @@ func (m Model) IsEmpty() bool {
 
 type Models []*Model
 
+// MergeMap appends models from b that are not already in a (by pointer identity).
 func (a *Models) MergeMap(b map[string]*Model) {
 	for _, v := range b {
 		insert := true
@@ -125,22 +129,24 @@ func (a *Models) MergeArray(b []*Model) {
 	return
 }
 
+// RequiredNess maps to Thrift field requiredness semantics.
 type RequiredNess int
 
 const (
-	RequiredNess_Default  RequiredNess = 0
+	RequiredNess_Default  RequiredNess = 0 // Thrift "default" requiredness
 	RequiredNess_Required RequiredNess = 1
 	RequiredNess_Optional RequiredNess = 2
 )
 
+// Type describes a Go type for code generation, bridging IDL types to Go types.
 type Type struct {
-	Name     string
-	Scope    *Model
-	Kind     Kind
-	Indirect bool
-	Category Category
-	Extra    []*Type // [{key_type},{value_type}] for map, [{element_type}] for list or set
-	HasNew   bool
+	Name     string   // Go type name (e.g. "int64", "MyStruct")
+	Scope    *Model   // owning model; nil means unresolved, &BaseModel means builtin
+	Kind     Kind     // Go type kind
+	Indirect bool     // whether this type is referenced indirectly (pointer)
+	Category Category // IDL semantic category
+	Extra    []*Type  // container element types: [elem] for list/set, [key, value] for map
+	HasNew   bool     // whether this type needs a constructor (e.g. structs, enums)
 }
 
 func (rt *Type) ResolveDefaultValue() string {
@@ -160,6 +166,9 @@ func (rt *Type) ResolveDefaultValue() string {
 	}
 }
 
+// ResolveNameForTypedef returns the fully qualified Go type name for a typedef alias.
+// Unlike ResolveName, it does not add pointer prefix for struct types since typedefs
+// define new named types rather than references.
 func (rt *Type) ResolveNameForTypedef(scope *Model) (string, error) {
 	if rt == nil {
 		return "", errors.New("type is nil")
@@ -209,6 +218,9 @@ func (rt *Type) ResolveNameForTypedef(scope *Model) (string, error) {
 	return name, nil
 }
 
+// ResolveName returns the fully qualified Go type name relative to scope.
+// For structs, it prepends "*" (pointer). For types from different packages,
+// it prepends the package name qualifier.
 func (rt *Type) ResolveName(scope *Model) (string, error) {
 	if rt == nil {
 		return "", fmt.Errorf("type is nil")
@@ -285,6 +297,7 @@ func (rt *Type) IsBaseType() bool {
 	return rt.Kind < KindComplex64
 }
 
+// IsSettable returns true if the type is a reference type that can be nil-checked.
 func (rt *Type) IsSettable() bool {
 	switch rt.Kind {
 	case KindArray, KindChan, KindFunc, KindInterface, KindMap, KindPtr, KindSlice, KindUnsafePointer:
@@ -352,13 +365,13 @@ type Field struct {
 	Scope            *Struct
 	Name             string
 	Type             *Type
-	IsSetDefault     bool
-	DefaultValue     Literal
-	Required         RequiredNess
-	Tags             Tags
+	IsSetDefault     bool         // whether a default value is explicitly set in IDL
+	DefaultValue     Literal      // the default value expression
+	Required         RequiredNess // Thrift requiredness
+	Tags             Tags         // struct field tags (json, query, form, etc.)
 	LeadingComments  string
 	TrailingComments string
-	IsPointer        bool
+	IsPointer        bool // whether to generate as pointer type (for optional fields)
 }
 
 type Oneof struct {
@@ -379,7 +392,7 @@ type Tags []Tag
 type Tag struct {
 	Key       string
 	Value     string
-	IsDefault bool // default tag
+	IsDefault bool // true if auto-generated (not explicitly set in IDL annotation)
 }
 
 func (ts Tags) String() string {

--- a/cmd/hz/generator/model_test.go
+++ b/cmd/hz/generator/model_test.go
@@ -116,7 +116,8 @@ func TestIdlGenerator_GenModel(t *testing.T) {
 					},
 					Enums: []model.Enum{
 						{
-							Name: "Sex",
+							Name:   "Sex",
+							GoType: "int",
 							Values: []model.Constant{
 								{
 									Name: "Male",

--- a/cmd/hz/generator/package.go
+++ b/cmd/hz/generator/package.go
@@ -48,33 +48,33 @@ type Service struct {
 	ServiceGenDir string         // handler_dir for handler_by_service
 }
 
-// HttpPackageGenerator is used to record the configuration related to generating hertz http code.
+// HttpPackageGenerator generates handler, router, model, and client code for one IDL package.
 type HttpPackageGenerator struct {
-	ConfigPath     string       // package template path
-	Backend        meta.Backend // model template
-	Options        []Option
-	CmdType        string
-	ProjPackage    string // go module for project
-	HandlerDir     string
-	RouterDir      string
-	ModelDir       string // like: biz/model or biz\model (Windows)
-	UseDir         string // XXX: should be UsePkg, not a filepath?
-	ClientDir      string // client dir for "new"/"update" command
-	IdlClientDir   string // client dir for "client" command
-	ForceClientDir string // client dir without namespace for "client" command
-	BaseDomain     string // request domain for "client" command
-	QueryEnumAsInt bool   // client code use number for query parameter
-	ServiceGenDir  string
+	ConfigPath     string       // path to custom package template YAML config
+	Backend        meta.Backend // model code generation backend (e.g. "golang")
+	Options        []Option     // model generation options (e.g. MarshalEnumToText)
+	CmdType        string       // current command: new/update/model/client
+	ProjPackage    string       // Go module path (e.g. "github.com/foo/bar")
+	HandlerDir     string       // relative path for handler output
+	RouterDir      string       // relative path for router output
+	ModelDir       string       // relative path for model output (e.g. "biz/model")
+	UseDir         string       // external model package to import instead of generating
+	ClientDir      string       // client output dir for "new"/"update" commands
+	IdlClientDir   string       // default client dir derived from IDL namespace (for "client" command)
+	ForceClientDir string       // client dir without IDL namespace subdirectories
+	BaseDomain     string       // default request domain for generated client code
+	QueryEnumAsInt bool         // use numeric values for enum query parameters in client code
+	ServiceGenDir  string       // per-service handler directory override
 
-	NeedModel            bool
-	HandlerByMethod      bool // generate handler files with method dimension
-	SnakeStyleMiddleware bool // use snake name style for middleware
-	SortRouter           bool
-	ForceUpdateClient    bool // force update 'hertz_client.go'
+	NeedModel            bool // whether to generate model .go files (false when -use is specified)
+	HandlerByMethod      bool // one handler file per method (vs one per service)
+	SnakeStyleMiddleware bool // use snake_case naming for middleware functions
+	SortRouter           bool // sort router registration for deterministic output
+	ForceUpdateClient    bool // regenerate hertz_client.go even if it exists
 
-	loadedBackend   Backend
-	curModel        *model.Model
-	processedModels map[*model.Model]bool
+	loadedBackend   Backend               // initialized model template backend
+	curModel        *model.Model          // model currently being rendered (for ROOT template func)
+	processedModels map[*model.Model]bool // tracks models already processed to avoid duplicates
 
 	TemplateGenerator
 }
@@ -139,6 +139,8 @@ func (pkgGen *HttpPackageGenerator) Init() error {
 	return pkgGen.TemplateGenerator.Init()
 }
 
+// checkInited ensures the generator is initialized. Returns true if using default config
+// (no custom ConfigPath), false if a custom config was loaded.
 func (pkgGen *HttpPackageGenerator) checkInited() (bool, error) {
 	if pkgGen.tpls == nil {
 		if err := pkgGen.Init(); err != nil {

--- a/cmd/hz/generator/router.go
+++ b/cmd/hz/generator/router.go
@@ -31,28 +31,35 @@ import (
 	"github.com/cloudwego/hertz/cmd/hz/util"
 )
 
+// Router holds the data needed to render the router registration template.
 type Router struct {
 	FilePath        string
 	PackageName     string
-	HandlerPackages map[string]string // {{basename}}:{{import_path}}
+	HandlerPackages map[string]string // package alias -> import path
 	Router          *RouterNode
 }
 
+// RouterNode represents a node in the routing tree. The tree structure mirrors
+// the URL path hierarchy. Each node may have:
+//   - Children: sub-path segments forming route groups
+//   - Handler + HttpMethod: a leaf endpoint registration
+//
+// The tree is used to generate nested router group code with middleware hooks.
 type RouterNode struct {
-	GroupName         string // current group name(the parent middleware name), used to register route. example: {{.GroupName}}.{{HttpMethod}}
-	MiddleWare        string // current node middleware, used to be group name for children.
-	HandlerMiddleware string
-	GroupMiddleware   string
-	PathPrefix        string
+	GroupName         string // parent's middleware var name, used for route registration (e.g. root.GET)
+	MiddleWare        string // this node's middleware var name, becomes GroupName for children
+	HandlerMiddleware string // middleware name specific to this handler (may differ from GroupMiddleware)
+	GroupMiddleware   string // middleware name for the route group (may use snake_case or camelCase)
+	PathPrefix        string // accumulated path prefix for snake-style middleware naming
 
 	Path     string
 	Parent   *RouterNode
 	Children childrenRouterInfo
 
-	Handler             string // {{HandlerPackage}}.{{HandlerName}}
-	HandlerPackage      string
-	HandlerPackageAlias string
-	HttpMethod          string
+	Handler             string // qualified handler call: "pkg.HandlerName"
+	HandlerPackage      string // handler import path
+	HandlerPackageAlias string // handler import alias
+	HttpMethod          string // HTTP method (GET, POST, etc.) or "" for group-only nodes
 }
 
 type RegisterInfo struct {
@@ -76,6 +83,9 @@ func (routerNode *RouterNode) Sort() {
 	sort.Sort(routerNode.Children)
 }
 
+// Update inserts a new route into the tree. It splits the path into segments,
+// finds the deepest existing node matching the path prefix, then inserts
+// remaining segments as new child nodes.
 func (routerNode *RouterNode) Update(method *HttpMethod, handlerType, handlerPkg string, sortRouter bool) error {
 	if method.Path == "" {
 		return fmt.Errorf("empty path for method '%s'", method.Name)
@@ -193,8 +203,12 @@ func (routerNode *RouterNode) DFS(i int, hook func(layer int, node *RouterNode) 
 	return nil
 }
 
+// handlerPkgMap tracks handler package -> unique alias mappings across the entire
+// generation session to ensure each handler package gets a unique import alias.
 var handlerPkgMap map[string]string
 
+// Insert adds child nodes for each remaining path segment. The last segment
+// gets the handler and HTTP method assignment.
 func (routerNode *RouterNode) Insert(name string, method *HttpMethod, handlerType string, paths []string, handlerPkg string, sortRouter bool) {
 	cur := routerNode
 	for i, p := range paths {
@@ -251,6 +265,9 @@ func getHttpMethod(method string) string {
 	return strings.ToUpper(method)
 }
 
+// FindNearest walks the tree to find the deepest node matching the given path segments.
+// Returns the parent node and the index of the first unmatched path segment.
+// When sortRouter is true, it also checks HTTP method to distinguish same-path different-method routes.
 func (routerNode *RouterNode) FindNearest(paths []string, method string, sortRouter bool) (*RouterNode, int) {
 	ns := len(paths)
 	cur := routerNode
@@ -287,6 +304,8 @@ func (c childrenRouterInfo) Len() int {
 
 // Less reports whether the element with
 // index i should sort before the element with index j.
+// Less sorts children: handler nodes (with HttpMethod) come before group nodes (without),
+// then alphabetically by path (ignoring leading non-letter chars like "/" and ":").
 func (c childrenRouterInfo) Less(i, j int) bool {
 	if c[i].HttpMethod == "" && c[j].HttpMethod != "" {
 		return false
@@ -327,6 +346,8 @@ var (
 	regImport     = regexp.MustCompile(`import \(\n`)
 )
 
+// updateRegister adds a new sub-router package registration call to the register.go file.
+// It inserts both the import statement and the registration call at the marked insert point.
 func (pkgGen *HttpPackageGenerator) updateRegister(pkg, rDir, pkgName string) error {
 	if pkgGen.tplsInfo[registerTplName].Disable {
 		return nil
@@ -378,6 +399,8 @@ func checkDupRegister(file []byte, insertReg string) bool {
 	return bytes.Contains(file, []byte("\t"+insertReg)) || bytes.Contains(file, []byte(" "+insertReg))
 }
 
+// appendMw appends a middleware name to the list, appending a numeric suffix if the name
+// already exists to ensure uniqueness (e.g. "mw", "mw0", "mw1", ...).
 func appendMw(mws []string, mw string) ([]string, string) {
 	for i := 0; true; i++ {
 		if i == math.MaxInt {
@@ -401,6 +424,9 @@ func stringsIncludes(strs []string, str string) bool {
 	return false
 }
 
+// genRouter generates the router registration file, middleware stubs, and register.go entries.
+// It first assigns unique middleware names to each tree node via DyeGroupName, then renders
+// the router template and updates middleware and registration files incrementally.
 func (pkgGen *HttpPackageGenerator) genRouter(pkg *HttpPackage, root *RouterNode, handlerPackage, routerDir, routerPackage string) error {
 	err := root.DyeGroupName(pkgGen.SnakeStyleMiddleware)
 	if err != nil {
@@ -470,6 +496,8 @@ func (pkgGen *HttpPackageGenerator) genRouter(pkg *HttpPackage, root *RouterNode
 	return nil
 }
 
+// updateMiddlewareReg appends new middleware stub functions to an existing middleware.go file.
+// Each middleware function is only added if its name pattern doesn't already appear in the file.
 func (pkgGen *HttpPackageGenerator) updateMiddlewareReg(router interface{}, middlewareTpl, filePath string) error {
 	if pkgGen.tplsInfo[middlewareTpl].Disable {
 		return nil

--- a/cmd/hz/generator/template.go
+++ b/cmd/hz/generator/template.go
@@ -36,10 +36,11 @@ type TemplateConfig struct {
 	Layouts []Template `yaml:"layouts"`
 }
 
+// UpdateBehavior type constants control how existing files are handled during "update" command.
 const (
-	Skip   = "skip"
-	Cover  = "cover"
-	Append = "append"
+	Skip   = "skip"   // do not modify existing file
+	Cover  = "cover"  // overwrite existing file completely
+	Append = "append" // append new content (e.g. new handler methods) to existing file
 )
 
 type Template struct {
@@ -158,8 +159,13 @@ func (tg *TemplateGenerator) loadLayout(layout Template, tplName string, isDefau
 	return nil
 }
 
+// Generate renders templates with the given input data and appends results to tg.files.
+// If tplName is specified, only that template is rendered to filepath.
+// If tplName is empty, all loaded templates are rendered (used for layout generation).
+// When input is a map, the "*" key provides global data merged into all templates,
+// and per-template data is keyed by template path.
 func (tg *TemplateGenerator) Generate(input interface{}, tplName, filepath string, noRepeat bool) error {
-	// check if "*" (global scope) data exists, and stores it to all
+	// Extract "*" (global scope) data that gets merged into every template's data.
 	var all map[string]interface{}
 	if data, ok := input.(map[string]interface{}); ok {
 		ad, ok := data["*"]
@@ -215,6 +221,8 @@ func (tg *TemplateGenerator) Generate(input interface{}, tplName, filepath strin
 	return nil
 }
 
+// Persist writes all accumulated files to disk, creating directories as needed.
+// Shell scripts (.sh) get executable permissions (0755), other files get 0644.
 func (tg *TemplateGenerator) Persist() error {
 	files := tg.files
 	outPath := tg.OutputDir
@@ -308,6 +316,8 @@ func (tg *TemplateGenerator) Files() []File {
 	return tg.files
 }
 
+// Degenerate removes all files and directories that were created by the template generator.
+// Only removes directories that didn't exist before generation (tracked in tg.dirs).
 func (tg *TemplateGenerator) Degenerate() error {
 	outPath := tg.OutputDir
 	if !filepath.IsAbs(outPath) {

--- a/cmd/hz/meta/manifest.go
+++ b/cmd/hz/meta/manifest.go
@@ -26,13 +26,16 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// ManifestFile is the project metadata file created by "hz new".
+// It records the hz version and directory layout so "hz update" can locate generated files.
 const ManifestFile = ".hz"
 
+// Manifest represents the contents of the .hz project metadata file.
 type Manifest struct {
-	Version    string `yaml:"hz version"`
-	HandlerDir string `yaml:"handlerDir"`
-	ModelDir   string `yaml:"modelDir"`
-	RouterDir  string `yaml:"routerDir"`
+	Version    string `yaml:"hz version"` // hz version that created/updated this project
+	HandlerDir string `yaml:"handlerDir"` // custom handler directory (empty = default)
+	ModelDir   string `yaml:"modelDir"`   // custom model directory (empty = default)
+	RouterDir  string `yaml:"routerDir"`  // custom router directory (empty = default)
 }
 
 var GoVersion *gv.Version
@@ -42,6 +45,7 @@ func init() {
 	GoVersion, _ = gv.NewVersion(Version)
 }
 
+// InitAndValidate loads the .hz manifest from dir and validates it belongs to a hertz project.
 func (manifest *Manifest) InitAndValidate(dir string) error {
 	m, err := loadConfigFile(filepath.Join(dir, ManifestFile))
 	if err != nil {

--- a/cmd/hz/test_hz_unix.sh
+++ b/cmd/hz/test_hz_unix.sh
@@ -1,93 +1,30 @@
-#! /usr/bin/env bash
-
+#!/usr/bin/env bash
+#
+# CI test script for hz on Linux/macOS.
+# Installs dependencies, then runs generate.sh with --verify --clean.
 
 set -e
 
-# const value define
-moduleName="github.com/cloudwego/hertz/cmd/hz/test"
-curDir=`pwd`
-thriftIDL=$curDir"/testdata/thrift/psm.thrift"
-protobuf2IDL=$curDir"/testdata/protobuf2/psm/psm.proto"
-proto2Search=$curDir"/testdata/protobuf2"
-protobuf3IDL=$curDir"/testdata/protobuf3/psm/psm.proto"
-proto3Search=$curDir"/testdata/protobuf3"
-protoSearch="/usr/local/include"
+cd "$(dirname "$0")"
 
-compile_hz() {
-  go build -o hz
-}
+LOCAL_DIR="$PWD/.local"
+mkdir -p "$LOCAL_DIR/bin"
+export PATH="$LOCAL_DIR/bin:$PATH"
 
+# install thriftgo
+go install github.com/cloudwego/thriftgo@latest
 
-PATH_BIN=$PWD/bin
-mkdir -p $PATH_BIN
-export PATH=$PATH_BIN:$PATH
+# install protoc if not already present (standard layout: bin/protoc + include/google/)
+if [ ! -f "$LOCAL_DIR/bin/protoc" ]; then
+  wget -q https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
+  unzip -qd "$LOCAL_DIR" protoc-3.19.4-linux-x86_64.zip
+  rm -f protoc-3.19.4-linux-x86_64.zip
+fi
 
-install_dependent_tools() {
-  # install thriftgo
-  go install github.com/cloudwego/thriftgo@latest
+# build hz
+go build -o hz .
 
-  # install protoc if not already downloaded
-  if [ ! -f "$PATH_BIN/protoc" ]; then
-    wget https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
-    unzip -d protoc-3.19.4-linux-x86_64 protoc-3.19.4-linux-x86_64.zip
-    cp protoc-3.19.4-linux-x86_64/bin/protoc $PATH_BIN
-    cp -r protoc-3.19.4-linux-x86_64/include/google $PATH_BIN
-  fi
-}
+# run all targets with build verification, cleanup after
+./generate.sh --hz ./hz --verify --clean thrift proto2 proto3
 
-go_tidy_build() {
-  # make sure we get the latest version for testing
-  go get github.com/cloudwego/hertz@main
-  go mod tidy && go build .
-}
-
-test_thrift() {
-  mkdir -p test
-  cd test
-  ../hz new --idl=$thriftIDL --mod=$moduleName -f --model_dir=hertz_model --handler_dir=hertz_handler --router_dir=hertz_router
-  go_tidy_build
-  ../hz update --idl=$thriftIDL
-  ../hz model --idl=$thriftIDL --model_dir=hertz_model
-  ../hz client --idl=$thriftIDL --client_dir=hertz_client
-  cd ..
-  rm -rf test
-}
-
-test_protobuf2() {
-  # test protobuf2
-  mkdir -p test
-  cd test
-  ../hz new -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL --mod=$moduleName -f --model_dir=hertz_model --handler_dir=hertz_handler --router_dir=hertz_router
-  go_tidy_build
-  ../hz update -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL
-  ../hz model -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL --model_dir=hertz_model
-  ../hz client -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL --client_dir=hertz_client
-  cd ..
-  rm -rf test
-}
-
-test_protobuf3() {
-  # test protobuf2
-  mkdir -p test
-  cd test
-  ../hz new -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL --mod=$moduleName -f --model_dir=hertz_model --handler_dir=hertz_handler --router_dir=hertz_router
-  go_tidy_build
-  ../hz update -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL
-  ../hz model -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL --model_dir=hertz_model
-  ../hz client -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL --client_dir=hertz_client
-  cd ..
-  rm -rf test
-}
-
-main() {
-  compile_hz
-  install_dependent_tools
-  echo "test thrift......"
-  test_thrift
-  echo "test protobuf2......"
-  test_protobuf2
-  echo "test protobuf3......"
-  test_protobuf3
-  echo "hz execute success"
-}
-main
+echo "hz execute success"

--- a/cmd/hz/test_hz_windows.sh
+++ b/cmd/hz/test_hz_windows.sh
@@ -1,81 +1,30 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
+#
+# CI test script for hz on Windows (Git Bash / WSL).
+# Installs dependencies, then runs generate.sh with --verify --clean.
 
 set -e
 
-# const value define
-moduleName="github.com/cloudwego/hertz/cmd/hz/test"
-curDir=`pwd`
-thriftIDL=$curDir"/testdata/thrift/psm.thrift"
-protobuf2IDL=$curDir"/testdata/protobuf2/psm/psm.proto"
-proto2Search=$curDir"/testdata/protobuf2"
-protobuf3IDL=$curDir"/testdata/protobuf3/psm/psm.proto"
-proto3Search=$curDir"/testdata/protobuf3"
-protoSearch=$curDir"/testdata/include"
+cd "$(dirname "$0")"
 
-compile_hz() {
-  go install .
-}
+LOCAL_DIR="$PWD/.local"
+mkdir -p "$LOCAL_DIR/bin"
+export PATH="$LOCAL_DIR/bin:$PATH"
 
-install_dependent_tools() {
- # install thriftgo
- go install github.com/cloudwego/thriftgo@latest
-}
+# install thriftgo
+go install github.com/cloudwego/thriftgo@latest
 
-go_tidy_build() {
-  # make sure we get the latest version for testing
-  go get github.com/cloudwego/hertz@main
-  go mod tidy && go build .
-}
+# install protoc if not already present (standard layout: bin/protoc + include/google/)
+if [ ! -f "$LOCAL_DIR/bin/protoc" ] && [ ! -f "$LOCAL_DIR/bin/protoc.exe" ]; then
+  curl -sLO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-win64.zip
+  unzip -qd "$LOCAL_DIR" protoc-3.19.4-win64.zip
+  rm -f protoc-3.19.4-win64.zip
+fi
 
-test_thrift() {
-  # test thrift
-  mkdir -p test
-  cd test
-  hz new --idl=$thriftIDL --mod=$moduleName -f --model_dir=hertz_model --handler_dir=hertz_handler --router_dir=hertz_router
-  go_tidy_build
-  hz update --idl=$thriftIDL
-  hz model --idl=$thriftIDL --model_dir=hertz_model
-  hz client --idl=$thriftIDL --client_dir=hertz_client
-  cd ..
-  rm -rf test
-}
+# build hz
+go build -o hz.exe .
 
-test_protobuf2() {
-  # test protobuf2
-  mkdir -p test
-  cd test
-  hz new -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL --mod=$moduleName -f --model_dir=hertz_model --handler_dir=hertz_handler --router_dir=hertz_router
-  go_tidy_build
-  hz update -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL
-  hz model -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL --model_dir=hertz_model
-  hz client -I=$protoSearch -I=$proto2Search --idl=$protobuf2IDL --client_dir=hertz_client
-  cd ..
-  rm -rf test
-}
+# run all targets with build verification, cleanup after
+./generate.sh --hz "$PWD/hz.exe" --verify --clean thrift proto2 proto3
 
-test_protobuf3() {
-  # test protobuf2
-  mkdir -p test
-  cd test
-  hz new -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL --mod=$moduleName -f --model_dir=hertz_model --handler_dir=hertz_handler --router_dir=hertz_router
-  go_tidy_build
-  hz update -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL
-  hz model -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL --model_dir=hertz_model
-  hz client -I=$protoSearch -I=$proto3Search --idl=$protobuf3IDL --client_dir=hertz_client
-  cd ..
-  rm -rf test
-}
-
-main() {
-  compile_hz
-  install_dependent_tools
-# todo: add thrift test when thriftgo fixed windows
-  echo "test thrift......"
-  test_thrift
-  echo "test protobuf2......"
-  test_protobuf2
-  echo "test protobuf3......"
-  test_protobuf3
-  echo "hz execute success"
-}
-main
+echo "hz execute success"

--- a/cmd/hz/thrift/plugin_test.go
+++ b/cmd/hz/thrift/plugin_test.go
@@ -17,31 +17,53 @@
 package thrift
 
 import (
-	"io/ioutil"
 	"testing"
 
+	"github.com/cloudwego/hertz/cmd/hz/config"
 	"github.com/cloudwego/hertz/cmd/hz/generator"
 	"github.com/cloudwego/hertz/cmd/hz/meta"
-	"github.com/cloudwego/thriftgo/plugin"
+	"github.com/cloudwego/hertz/cmd/hz/util"
+	"github.com/cloudwego/thriftgo/parser"
+	thriftgo_plugin "github.com/cloudwego/thriftgo/plugin"
 )
 
-func TestRun(t *testing.T) {
-	data, err := ioutil.ReadFile("../testdata/request_thrift.out")
+// buildTestRequest parses the test thrift IDL and builds a thriftgo plugin request.
+func buildTestRequest(t *testing.T) *thriftgo_plugin.Request {
+	t.Helper()
+	idlPath := "../testdata/thrift/psm.thrift"
+	ast, err := parser.ParseFile(idlPath, []string{"../testdata/thrift"}, true)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("parse thrift IDL failed: %v", err)
 	}
 
-	req, err := plugin.UnmarshalRequest(data)
+	args := config.NewArgument()
+	args.Gomod = "github.com/cloudwego/hertz/test"
+	args.OutDir = t.TempDir()
+	args.CmdType = meta.CmdNew
+	packed, err := util.PackArgs(args)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("pack args failed: %v", err)
 	}
+
+	return &thriftgo_plugin.Request{
+		Version:             "0.2.0",
+		GeneratorParameters: []string{"go:reserve_comments,gen_json_tag=false,package_prefix=github.com/cloudwego/hertz/test/biz/model"},
+		PluginParameters:    packed,
+		Language:            "go",
+		OutputPath:          args.OutDir,
+		Recursive:           true,
+		AST:                 ast,
+	}
+}
+
+func TestRun(t *testing.T) {
+	req := buildTestRequest(t)
 
 	plu := new(Plugin)
 	plu.setLogger()
-
 	plu.req = req
 
-	_, err = plu.parseArgs()
+	_, err := plu.parseArgs()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -105,15 +127,12 @@ func TestRun(t *testing.T) {
 	}
 	files, err := sg.GetFormatAndExcludedFiles()
 	if err != nil {
-		return
+		t.Fatal(err)
 	}
 
 	res, err := plu.GetResponse(files, sg.OutputDir)
 	if err != nil {
-		return
+		t.Fatal(err)
 	}
 	plu.response(res)
-	if err != nil {
-		return
-	}
 }

--- a/cmd/hz/util/data.go
+++ b/cmd/hz/util/data.go
@@ -51,6 +51,9 @@ func CopyString2StringMap(from, to map[string]string) {
 	}
 }
 
+// PackArgs serializes a struct into a flat list of "Key=Value" strings for passing
+// arguments through the protoc/thriftgo plugin interface. Slices are joined with ";",
+// maps are encoded as "k1=v1;k2=v2". Only exported, non-zero fields are included.
 func PackArgs(c interface{}) (res []string, err error) {
 	t := reflect.TypeOf(c)
 	v := reflect.ValueOf(c)
@@ -120,6 +123,8 @@ func PackArgs(c interface{}) (res []string, err error) {
 	return res, nil
 }
 
+// UnpackArgs deserializes a "Key=Value" string list (from PackArgs) back into a struct.
+// This is the inverse of PackArgs, used by the plugin process to receive configuration.
 func UnpackArgs(args []string, c interface{}) error {
 	m, err := MapForm(args)
 	if err != nil {
@@ -291,6 +296,9 @@ func ImportToSanitizedPath(path string) string {
 	return path
 }
 
+// ToVarName joins path segments and converts them to a valid Go identifier.
+// Non-alphanumeric characters are replaced with '_', and leading digits are dropped.
+// Segments are joined with "__" (e.g. ["api","v1"] -> "api__v1").
 func ToVarName(paths []string) string {
 	ps := strings.Join(paths, "__")
 	input := []byte(url.PathEscape(ps))
@@ -310,6 +318,8 @@ func ToVarName(paths []string) string {
 	return string(out)
 }
 
+// SplitGoTags splits a Go struct tag string into individual key:"value" pairs,
+// respecting quoted values that may contain spaces.
 func SplitGoTags(input string) []string {
 	out := make([]string, 0, 4)
 	ns := len(input)
@@ -382,7 +392,8 @@ func GetHandlerPackageUniqueName(name string) (string, error) {
 	return name, nil
 }
 
-// getUniqueName can get a non-repeating variable name
+// getUniqueName returns a unique name by appending numeric suffixes if needed.
+// The uniqueNameSet is a global registry that persists across calls within a generation session.
 func getUniqueName(name string, uniqueNameSet map[string]bool) (string, error) {
 	uniqueName := name
 	if _, exist := uniqueNameSet[uniqueName]; exist {

--- a/cmd/hz/util/logs/std.go
+++ b/cmd/hz/util/logs/std.go
@@ -24,16 +24,19 @@ import (
 	"os"
 )
 
+// StdLogger buffers log output in memory and flushes to stderr.
+// By default, each log call flushes immediately. When Defer is true, output
+// is buffered until Flush() is called explicitly (useful for capturing logs in tests).
 type StdLogger struct {
 	level      int
-	outLogger  *log.Logger
-	warnLogger *log.Logger
-	errLogger  *log.Logger
-	out        *bytes.Buffer
-	warn       *bytes.Buffer
-	err        *bytes.Buffer
-	Defer      bool
-	ErrOnly    bool
+	outLogger  *log.Logger   // handles Debug and Info levels
+	warnLogger *log.Logger   // handles Warn level
+	errLogger  *log.Logger   // handles Error level
+	out        *bytes.Buffer // buffer for outLogger
+	warn       *bytes.Buffer // buffer for warnLogger
+	err        *bytes.Buffer // buffer for errLogger
+	Defer      bool          // if true, buffer logs until Flush() is called
+	ErrOnly    bool          // if true, Flush() only flushes error/warn (suppresses info/debug)
 }
 
 func NewStdLogger(level int) *StdLogger {

--- a/cmd/hz/util/string.go
+++ b/cmd/hz/util/string.go
@@ -23,6 +23,8 @@ import (
 	"unsafe"
 )
 
+// Str2Bytes performs a zero-copy string to byte slice conversion using unsafe pointer casting.
+// The returned slice shares memory with the input string; do NOT modify it.
 func Str2Bytes(in string) (out []byte) {
 	op := (*reflect.SliceHeader)(unsafe.Pointer(&out))
 	ip := (*reflect.StringHeader)(unsafe.Pointer(&in))
@@ -55,11 +57,13 @@ func AddSlashForComments(s string) string {
 	return s
 }
 
-// CamelString converts the string 's' to a camel string
+// CamelString converts the string 's' to PascalCase (upper camel case).
+// Underscores before lowercase letters are removed and the following letter is capitalized.
+// State flags: j = next char should be uppercased (after underscore), k = seen first letter already.
 func CamelString(s string) string {
 	data := make([]byte, 0, len(s))
-	j := false
-	k := false
+	j := false // capitalize next character
+	k := false // have we seen the first letter
 	num := len(s) - 1
 	for i := 0; i <= num; i++ {
 		d := s[i]
@@ -67,23 +71,25 @@ func CamelString(s string) string {
 			k = true
 		}
 		if d >= 'a' && d <= 'z' && (j || k == false) {
-			d = d - 32
+			d = d - 32 // to uppercase
 			j = false
 			k = true
 		}
 		if k && d == '_' && num > i && s[i+1] >= 'a' && s[i+1] <= 'z' {
 			j = true
-			continue
+			continue // skip the underscore
 		}
 		data = append(data, d)
 	}
 	return Bytes2Str(data[:])
 }
 
-// SnakeString converts the string 's' to a snake string
+// SnakeString converts the string 's' to snake_case.
+// Inserts '_' before uppercase letters that follow a lowercase letter or non-underscore.
+// j tracks whether we've seen a non-underscore lowercase char (to avoid leading underscores).
 func SnakeString(s string) string {
 	data := make([]byte, 0, len(s)*2)
-	j := false
+	j := false // true after seeing a non-underscore char (prevents "_" before first upper)
 	for _, d := range Str2Bytes(s) {
 		if d >= 'A' && d <= 'Z' {
 			if j {


### PR DESCRIPTION
Add a comprehensive README.md documenting hz's architecture, dual-mode execution model, code generation pipeline, and template system.

Add comments to unclear code across 17 source files in cmd/hz/ covering the model type system, router tree construction, template generation, handler/client codegen, argument serialization, and plugin architecture.

Fix two pre-existing test failures:
- generator/model_test: add missing GoType field to Enum test data
- thrift/plugin_test: generate fixture programmatically instead of depending on a never-committed binary file (request_thrift.out)