### PR TITLE
docs: clarify multipart pre-parse still applies under WithStreamBody

### DIFF
--- a/pkg/app/server/option.go
+++ b/pkg/app/server/option.go
@@ -246,6 +246,11 @@ func WithKeepAlive(b bool) config.Option {
 // StreamRequestBody enables streaming request body,
 // and calls the handler sooner when given body is
 // larger than the current limit.
+//
+// Note: multipart form requests are still pre-parsed even when streaming is
+// enabled (the body is fully consumed into memory or a temp file before the
+// handler runs). To stream multipart bodies as well, also pass
+// WithDisablePreParseMultipartForm(true).
 func WithStreamBody(b bool) config.Option {
 	return config.Option{F: func(o *config.Options) {
 		o.StreamRequestBody = b


### PR DESCRIPTION
## Summary
- Document that `WithStreamBody(true)` still pre-parses multipart form requests (body fully buffered, large files spilled to temp file) before the handler runs.
- Point users at `WithDisablePreParseMultipartForm(true)` when they actually want to stream multipart bodies.

## Motivation
The two options are independent today, but the interaction is non-obvious: enabling stream body suggests multipart uploads will be streamed, when in fact `ContinueReadBodyStream` still calls `protocol.ParseMultipartForm` on known-length multipart requests. Calling out the interaction in godoc is a no-risk way to set expectations without breaking existing callers that rely on `ctx.MultipartForm()` working under `WithStreamBody(true)`.

## Test plan
- [ ] Docs-only change; no behavior modified.