### PR TITLE
fix(http1): improve robustness of request header parsing 

### DIFF
--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -88,6 +88,9 @@ func ReadHeaderWithLimit(h *protocol.RequestHeader, r network.Reader, maxHeaderB
 			continue
 		}
 		n = r.Len()
+		if n == 0 {
+			n = 1
+		}
 	}
 }
 
@@ -128,10 +131,10 @@ func parse(h *protocol.RequestHeader, buf []byte) (int, error) {
 		return 0, err
 	}
 	rawHeaders, _, err := ext.ReadRawHeaders(h.RawHeaders()[:0], buf[m:])
-	h.SetRawHeaders(rawHeaders)
 	if err != nil {
 		return 0, err
 	}
+	h.SetRawHeaders(rawHeaders)
 	n, err := parseHeaders(h, buf[m:])
 	if err != nil {
 		return 0, err
@@ -155,6 +158,9 @@ var errMalformedHTTPRequest = errors.New("malformed HTTP request")
 func parseFirstLine(h *protocol.RequestHeader, buf []byte) (int, error) {
 	b, leftb, err := utils.NextLine(buf)
 	if err != nil {
+		if len(buf) == 0 {
+			return 0, err
+		}
 		// errs.ErrNeedMore?
 		// check malformed HTTP request before reading more data
 		// NOTE:
@@ -261,8 +267,15 @@ func parseHeaders(h *protocol.RequestHeader, buf []byte) (int, error) {
 							}
 							h.InitContentLengthWithValue(-2)
 						} else {
-							h.InitContentLengthWithValue(contentLength)
-							h.SetContentLengthBytes(s.Value)
+							if h.ContentLength() >= 0 && contentLength != h.ContentLength() {
+								if err == nil {
+									err = fmt.Errorf("conflicting Content-Length header values: %d and %d", h.ContentLength(), contentLength)
+								}
+								h.InitContentLengthWithValue(-2)
+							} else {
+								h.InitContentLengthWithValue(contentLength)
+								h.SetContentLengthBytes(s.Value)
+							}
 						}
 					}
 					continue


### PR DESCRIPTION
 Closes #1497                                                                                                                                                 
                                                                                                                                                               
  ## Summary                                                                                                                                                   
  - Move `SetRawHeaders` call to after `ReadRawHeaders` error check in                                                                                         
    `parse()`, preventing unnecessary state mutation on parse failure                                                                                          
  - Add defensive empty-buffer guard in `parseFirstLine()` before the                                                                                          
    method-char validation loop                                                                                                                                
  - Add `n=0` guard in `ReadHeaderWithLimit()` to prevent degenerate                                                                                           
    `peek(0)` path                                                                                                                                             
  - Detect conflicting duplicate `Content-Length` values and reject                                                                                            
    them per RFC 7230 Section 3.3.2 (identical duplicates are accepted)                                                                                        
                                                                                                                                                               
  ## Impact                                                                                                                                                    
  - Changes 1–3: pure defensive improvements, zero behavioral change                                                                                           
    for valid inputs                                                                                                                                           
  - Change 4: only rejects HTTP/1.1 messages that are already invalid                                                                                          
    per RFC 7230 (conflicting Content-Length values)                                                                                                           
                                                                                                                                                               
  ## Test plan                                                                                                                                                 
  - [x] All existing tests in `pkg/protocol/http1/req/` pass                                                                                                   
  - [x] No regressions in `pkg/protocol/http1/resp/` or                                                                                                        
        `pkg/protocol/http1/ext/` 

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->