### PR TITLE
feat: add context-aware LoadbalancerCtx for client load balancing

### DIFF
--- a/pkg/app/client/loadbalance/lbcache.go
+++ b/pkg/app/client/loadbalance/lbcache.go
@@ -49,7 +49,8 @@ type BalancerFactory struct {
 	opts     Options
 	cache    sync.Map // key -> LoadBalancer
 	resolver discovery.Resolver
-	balancer Loadbalancer
+	impl     Loadbalancer
+	implCtx  LoadbalancerCtx // non-nil iff impl also implements LoadbalancerCtx
 	sfg      singleflight.Group
 }
 
@@ -72,8 +73,9 @@ func NewBalancerFactory(config Config) *BalancerFactory {
 		b := &BalancerFactory{
 			opts:     config.LbOpts,
 			resolver: config.Resolver,
-			balancer: config.Balancer,
+			impl:     config.Balancer,
 		}
+		b.implCtx, _ = config.Balancer.(LoadbalancerCtx)
 		go b.watcher()
 		go b.refresh()
 		balancerFactories.Store(uniqueKey, b)
@@ -93,7 +95,7 @@ func (b *BalancerFactory) watcher() {
 				// (avoid being immediate delete the balancer which had been created recently)
 			} else {
 				b.cache.Delete(key)
-				b.balancer.Delete(key.(string))
+				b.impl.Delete(key.(string))
 			}
 			return true
 		})
@@ -118,7 +120,7 @@ func (b *BalancerFactory) refresh() {
 			cache := value.(*cacheResult)
 			cache.res.Store(res)
 			atomic.StoreInt32(&cache.expire, 0)
-			b.balancer.Rebalance(res)
+			b.impl.Rebalance(res)
 			return true
 		})
 	}
@@ -130,7 +132,13 @@ func (b *BalancerFactory) GetInstance(ctx context.Context, req *protocol.Request
 		return nil, err
 	}
 	atomic.StoreInt32(&cacheRes.expire, 0)
-	ins := b.balancer.Pick(cacheRes.res.Load().(discovery.Result))
+	res := cacheRes.res.Load().(discovery.Result)
+	var ins discovery.Instance
+	if b.implCtx != nil {
+		ins = b.implCtx.PickCtx(ctx, req, res)
+	} else {
+		ins = b.impl.Pick(res)
+	}
 	if ins == nil {
 		hlog.SystemLogger().Errorf("null instance. serviceName: %s, options: %v", string(req.Host()), req.Options())
 		return nil, errors.NewPublic("instance not found")
@@ -155,7 +163,7 @@ func (b *BalancerFactory) getCacheResult(ctx context.Context, req *protocol.Requ
 		renameResultCacheKey(&res, b.resolver.Name())
 		cache.res.Store(res)
 		atomic.StoreInt32(&cache.expire, 0)
-		b.balancer.Rebalance(res)
+		b.impl.Rebalance(res)
 		b.cache.Store(target, cache)
 		return cache, nil
 	})

--- a/pkg/app/client/loadbalance/lbcache_test.go
+++ b/pkg/app/client/loadbalance/lbcache_test.go
@@ -210,3 +210,71 @@ func (m mockLoadbalancer) Pick(d discovery.Result) discovery.Instance {
 	}
 	return nil
 }
+
+type mockLoadbalancerCtx struct {
+	mockLoadbalancer
+	pickCtxFunc func(ctx context.Context, req *protocol.Request, d discovery.Result) discovery.Instance
+}
+
+func (m mockLoadbalancerCtx) PickCtx(ctx context.Context, req *protocol.Request, d discovery.Result) discovery.Instance {
+	if m.pickCtxFunc != nil {
+		return m.pickCtxFunc(ctx, req, d)
+	}
+	return nil
+}
+
+func TestLoadbalancerCtx(t *testing.T) {
+	insA := discovery.NewInstance("tcp", "10.0.0.1:80", 10, map[string]string{"region": "us"})
+	insB := discovery.NewInstance("tcp", "10.0.0.2:80", 10, map[string]string{"region": "eu"})
+	r := &discovery.SynthesizedResolver{
+		ResolveFunc: func(ctx context.Context, key string) (discovery.Result, error) {
+			return discovery.Result{CacheKey: key, Instances: []discovery.Instance{insA, insB}}, nil
+		},
+		TargetFunc: func(ctx context.Context, target *discovery.TargetInfo) string { return target.Host },
+		NameFunc:   func() string { return t.Name() },
+	}
+
+	type ctxKey struct{}
+	var pickCtxCalled, pickCalled int32
+
+	lb := mockLoadbalancerCtx{
+		mockLoadbalancer: mockLoadbalancer{
+			pickFunc: func(d discovery.Result) discovery.Instance {
+				atomic.AddInt32(&pickCalled, 1)
+				return d.Instances[0]
+			},
+			nameFunc: func() string { return "ctxLB" },
+		},
+		pickCtxFunc: func(ctx context.Context, req *protocol.Request, d discovery.Result) discovery.Instance {
+			atomic.AddInt32(&pickCtxCalled, 1)
+			want, _ := ctx.Value(ctxKey{}).(string)
+			for _, in := range d.Instances {
+				if v, _ := in.Tag("region"); v == want {
+					return in
+				}
+			}
+			return d.Instances[0]
+		},
+	}
+
+	blf := NewBalancerFactory(Config{Balancer: lb, LbOpts: DefaultLbOpts, Resolver: r})
+	req := &protocol.Request{}
+	req.SetHost("ctx.svc")
+
+	ctx := context.WithValue(context.Background(), ctxKey{}, "eu")
+	ins, err := blf.GetInstance(ctx, req)
+	assert.Assert(t, err == nil, err)
+	assert.Assert(t, ins.Address().String() == "10.0.0.2:80", ins.Address().String())
+	assert.Assert(t, atomic.LoadInt32(&pickCtxCalled) == 1)
+	assert.Assert(t, atomic.LoadInt32(&pickCalled) == 0)
+
+	// Plain Loadbalancer still falls back to Pick.
+	plainLB := mockLoadbalancer{
+		pickFunc: func(d discovery.Result) discovery.Instance { return d.Instances[0] },
+		nameFunc: func() string { return "plainLB" },
+	}
+	blf2 := NewBalancerFactory(Config{Balancer: plainLB, LbOpts: DefaultLbOpts, Resolver: r})
+	ins2, err := blf2.GetInstance(context.Background(), req)
+	assert.Assert(t, err == nil, err)
+	assert.Assert(t, ins2.Address().String() == "10.0.0.1:80")
+}

--- a/pkg/app/client/loadbalance/loadbalance.go
+++ b/pkg/app/client/loadbalance/loadbalance.go
@@ -17,9 +17,11 @@
 package loadbalance
 
 import (
+	"context"
 	"time"
 
 	"github.com/cloudwego/hertz/pkg/app/client/discovery"
+	"github.com/cloudwego/hertz/pkg/protocol"
 )
 
 // Loadbalancer picks instance for the given service discovery result.
@@ -35,6 +37,21 @@ type Loadbalancer interface {
 
 	// Name returns the name of the Loadbalancer.
 	Name() string
+}
+
+// LoadbalancerCtx is an optional extension of Loadbalancer that is aware of
+// the per-call context and request. When a Loadbalancer also implements this
+// interface, BalancerFactory.GetInstance prefers PickCtx over Pick so the
+// balancer can make decisions based on ctx values or request fields (e.g.
+// region/zone affinity, tenant routing, header-based stickiness, gray release).
+//
+// Implementations should fall back to plain Pick semantics when ctx/req carry
+// no relevant information.
+type LoadbalancerCtx interface {
+	Loadbalancer
+
+	// PickCtx selects an instance with access to the request context.
+	PickCtx(ctx context.Context, req *protocol.Request, e discovery.Result) discovery.Instance
 }
 
 const (


### PR DESCRIPTION
Closes #1471

## Summary

- Add opt-in `LoadbalancerCtx` interface in `pkg/app/client/loadbalance` that exposes `ctx context.Context` and `*protocol.Request` to `PickCtx`, enabling routing decisions based on request fields or ctx values (region affinity, tenant routing, header-based stickiness, gray release, etc.).
- `BalancerFactory` now caches the type assertion once at construction; the per-call hot path is a simple nil-check on `implCtx`.
- 100% backward compatible — balancers that only implement the existing `Loadbalancer` interface continue to work unchanged through `Pick`.

## Motivation

The current `Loadbalancer.Pick(discovery.Result)` is context-unaware. The caller `BalancerFactory.GetInstance` already has both `ctx` and `*protocol.Request` in scope, but drops them before calling `Pick`. This prevents implementing common patterns like region/zone-affine balancing, header-based sticky routing, or context-tag-driven gray release without monkey-patching the cache layer.

## Design notes

- Opt-in via type assertion (no breaking change to `Loadbalancer`).
- Assertion done once in `NewBalancerFactory`, cached as `implCtx LoadbalancerCtx` on the factory; per-call dispatch is a nil-check, not a type assertion.
- Resolver-side ctx (used in the periodic `refresh()` path with `context.Background()`) is intentionally out of scope here — it is a resolver concern, not a balancer concern.

## Test plan

- [x] `go test -race -timeout 60s ./pkg/app/client/loadbalance/...` passes
- [x] `go vet ./pkg/app/client/loadbalance/...` clean
- [x] `go build ./...` clean
- [x] New `TestLoadbalancerCtx` verifies:
  - balancer implementing `LoadbalancerCtx` is dispatched via `PickCtx` (not `Pick`), and can route by `ctx.Value`
  - plain `Loadbalancer` still falls back to `Pick` unchanged
- [x] All existing tests in the package still pass