### PR TITLE
fix: use %w verb for error wrapping in multipart handling

### DIFF
--- a/pkg/protocol/http1/req/request.go
+++ b/pkg/protocol/http1/req/request.go
@@ -211,13 +211,13 @@ func write(req *protocol.Request, w network.Writer, usingProxy bool) error {
 	body := req.BodyBytes()
 	err := handleMultipart(req)
 	if err != nil {
-		return fmt.Errorf("error when handle multipart: %s", err)
+		return fmt.Errorf("error when handle multipart: %w", err)
 	}
 	if req.OnlyMultipartForm() {
 		m, _ := req.MultipartForm() // req.multipartForm != nil
 		body, err = protocol.MarshalMultipartForm(m, req.MultipartFormBoundary())
 		if err != nil {
-			return fmt.Errorf("error when marshaling multipart form: %s", err)
+			return fmt.Errorf("error when marshaling multipart form: %w", err)
 		}
 		req.Header.SetMultipartFormBoundary(req.MultipartFormBoundary())
 	}


### PR DESCRIPTION
## Summary
Use `fmt.Errorf` with `%w` instead of `%s` for error wrapping in multipart request handling (`pkg/protocol/http1/req/request.go`).

This preserves the error chain, enabling `errors.Is()` and `errors.As()` checks on the returned errors, which is the idiomatic Go pattern since Go 1.13.

## Changes
- Line 214: `fmt.Errorf("error when handle multipart: %s", err)` → `%w`
- Line 220: `fmt.Errorf("error when marshaling multipart form: %s", err)` → `%w`

## Test Plan
- [x] Existing tests pass (no behavior change)
- [x] `go vet` passes