### PR TITLE
chore(protocol): remove redundant nil File-map check in Request.FormFile

### DIFF
--- a/pkg/protocol/request.go
+++ b/pkg/protocol/request.go
@@ -308,9 +308,6 @@ func (req *Request) FormFile(name string) (*multipart.FileHeader, error) {
 	if err != nil {
 		return nil, err
 	}
-	if mf.File == nil {
-		return nil, err
-	}
 	fhh := mf.File[name]
 	if fhh == nil {
 		return nil, ErrMissingFile


### PR DESCRIPTION
Change-Id: Id7bf1485b0aefa27826043ab90e9558ec6feffa6

#### What type of PR is this?

  chore: remove 3 lines of unused code in pkg/protocol/request.go

#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

zh(optional): 删除pkg/protocol/request.go下三行无用代码：
Go 标准库的 multipart.ReadForm 即使没有 file part 也会返回 File: map[string][]*FileHeader{} （非 nil map），即使返回nil map，后续直接读也会返回nil

``` 
// 标准库实现
func (r *Reader) readForm(maxMemory int64) (_ *Form, err error) {
	form := &Form{make(map[string][]string), make(map[string][]*FileHeader)}
        / .....
}
```


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->