### PR TITLE
docs(route): fix comment - anyChild node prefix is `*`, not only `:`

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -341,7 +341,7 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 			searchIndex -= len(previous.prefix)
 		} else {
 			paramIndex--
-			// for param/any node.prefix value is always `:` so we can not deduce searchIndex from that and must use pValue
+			// for param/any node.prefix value is always `:` or `*` so we can not deduce searchIndex from that and must use pValue
 			// for that index as it would also contain part of path we cut off before moving into node we are backtracking from
 			searchIndex -= len((*paramsPointer)[paramIndex].Value)
 			(*paramsPointer) = (*paramsPointer)[:paramIndex]


### PR DESCRIPTION
#### What type of PR is this?
docs

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: The comment says param/any node prefix is "always `:`", but anyChild actually uses `*`. Fixed to reflect both.
zh: 注释中原写 param/any 节点前缀"始终为 `:`"，但 anyChild 实际使用 `*`。修正为同时体现两种情况。

#### (Optional) Which issue(s) this PR fixes:
None