### PR TITLE
perf(router): replace strings.Index with strings.IndexByte in param parsing

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -108,7 +108,6 @@ const (
 	akind
 	paramLabel = byte(':')
 	anyLabel   = byte('*')
-	slash      = "/"
 	nilString  = ""
 )
 
@@ -402,7 +401,7 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 		// Param node
 		if child := cn.paramChild; search != nilString && child != nil {
 			cn = child
-			i := strings.Index(search, slash)
+			i := strings.IndexByte(search, '/')
 			if i == -1 {
 				i = len(search)
 			}


### PR DESCRIPTION
#### What type of this PR?
perf

#### Check the PR title.
- [x] This PR title match the format: `<type>(optional scope): <description>`
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

#### (Optional) Translate the PR title into Chinese.
perf: 使用 strings.IndexByte 优化路由参数解析

#### (Optional) More detailed description for this PR.
en:
Replace `strings.Index` with `strings.IndexByte` in route param parsing for better performance.
All tests pass.

zh(optional):
在路由参数解析中用 `strings.IndexByte` 替换 `strings.Index`，提升性能。
测试全部通过