### PR TITLE
refactor(route): remove unreachable backtracking branch for akind node

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -325,11 +325,7 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 		valid = cn != nil
 
 		// Next node type by priority
-		if previous.kind == akind {
-			nextNodeKind = skind
-		} else {
-			nextNodeKind = previous.kind + 1
-		}
+		nextNodeKind = previous.kind + 1
 
 		if fromKind == skind {
 			// when backtracking is done from static kind block we did not change search so nothing to restore


### PR DESCRIPTION
#### What type of PR is this?

refactor

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level.

refactor(route): remove unreachable backtracking branch for akind node

#### (Optional) Translate the PR title into Chinese.

重构(route): 移除 any 节点回溯逻辑中的不可达分支

#### (Optional) More detailed description for this PR.

en:
While reading pkg/route/tree.go, the following logic was noticed in backtrackToNextNodeKind():

if previous.kind == akind {
    nextNodeKind = skind
} else {
    nextNodeKind = previous.kind + 1
}

The previous.kind == akind branch appears to be unreachable in the current implementation.

Evidence:
1. Control-flow: The only path entering an akind node exits the search loop immediately via break, so execution never reaches backtrackToNextNodeKind(akind).
2. Test verification: A panic guard was temporarily added in this branch and go test ./... -count=1 passed without triggering the panic.
3. History: This branch has existed since early versions, likely a defensive transition inherited from an earlier implementation.

Change: Removed the special case, simplifying to nextNodeKind = previous.kind + 1. No functional change. All existing tests pass.

zh(optional):
在阅读 pkg/route/tree.go 时，发现 backtrackToNextNodeKind() 中存在以下逻辑：

if previous.kind == akind {
    nextNodeKind = skind
} else {
    nextNodeKind = previous.kind + 1
}

其中 previous.kind == akind 分支在当前实现中似乎是不可达的。

分析：
1. 控制流：唯一进入 akind 节点的路径会立即通过 break 退出搜索循环，执行流程不会到达 backtrackToNextNodeKind(akind)。
2. 测试验证：在该分支中临时添加了 panic 守卫，运行 go test ./... -count=1 全部通过，panic 从未触发。
3. 历史追溯：该分支从早期版本就存在，可能是从更早实现中遗留的防御性过渡逻辑。

修改：移除特殊分支，简化为 nextNodeKind = previous.kind + 1。无功能变更，所有已有测试均通过。

#### (Optional) Which issue(s) this PR fixes:
  Fixes #1504 
#### (Optional) The PR that updates user documentation: