### PR TITLE
fix: reject duplicate param names in route registration

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -147,10 +147,30 @@ func checkPathValid(path string) {
 	}
 }
 
+func checkDuplicateParams(path string) {
+	seen := make(map[string]bool)
+
+	for i := 0; i < len(path); i++ {
+		if path[i] == ':' {
+			start := i + 1
+			end := start
+			for end < len(path) && path[end] != '/' {
+				end++
+			}
+			name := path[start:end]
+			if seen[name] {
+				panic(fmt.Sprintf("duplicate param name %q in path %q", name, path))
+			}
+			seen[name] = true
+			i = end - 1
+		}
+	}
+}
+
 // addRoute adds a node with the given handle to the path.
 func (r *router) addRoute(path string, h app.HandlersChain) {
 	checkPathValid(path)
-
+	checkDuplicateParams(path)
 	var (
 		pnames []string // Param names
 		ppath  = path   // Pristine path

--- a/pkg/route/tree_test.go
+++ b/pkg/route/tree_test.go
@@ -735,3 +735,14 @@ func TestTreeParamNotOptimize(t *testing.T) {
 		{"/1", false, "/:paramb", param.Params{param.Param{Key: "paramb", Value: "1"}}},
 	})
 }
+
+func TestDuplicateParamNamePanic(t *testing.T) {
+	tree := &router{method: "GET", root: &node{}}
+
+	recv := catchPanic(func() {
+		tree.addRoute("/user/:id/order/:id", fakeHandler("/user/:id/order/:id"))
+	})
+	if recv == nil {
+		t.Error("expected panic for duplicate param names, but got none")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.

fix: 路由注册时拒绝重复参数名

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
When a route contains duplicate parameter names in different path segments, such as `/user/:id/order/:id`, `Params.ByName("id")` always returns the first matched value. As a result, the later parameter value cannot be retrieved, which may lead to subtle and hard-to-debug issues.

This PR adds `checkDuplicateParams` to detect and reject such routes during registration, with a clear panic message. This makes invalid route definitions fail fast instead of causing unexpected runtime behavior.

zh:
当路由在不同路径段中包含重复参数名时，例如 `/user/:id/order/:id`，`Params.ByName("id")` 始终只会返回第一个匹配到的值，后续同名参数的值无法获取。这可能导致隐蔽且难以排查的问题。

本 PR 新增 `checkDuplicateParams`，在路由注册阶段检测并拒绝此类路由，并给出明确的 panic 信息。这样可以让非法路由定义尽早失败，避免运行时出现非预期行为。

#### (Optional) Which issue(s) this PR fixes:

#### (Optional) The PR that updates user documentation: