### PR TITLE
fix(route): clearer error message when param/wildcard name conflicts at same path position

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -295,6 +295,19 @@ func (r *router) insert(path string, h app.HandlersChain, t kind, ppath string, 
 			currentNode.isLeaf = currentNode.children == nil && currentNode.paramChild == nil && currentNode.anyChild == nil
 		} else {
 			// Node already exists
+			if (currentNode.kind == pkind || currentNode.kind == akind) && currentNode.handlers != nil && h != nil {
+				if len(currentNode.pnames) > 0 && len(pnames) > 0 {
+					existing := currentNode.pnames[len(currentNode.pnames)-1]
+					incoming := pnames[len(pnames)-1]
+					if existing != incoming {
+						panic(fmt.Sprintf(
+							"wildcard name mismatch at the same position: %q vs %q",
+							existing, incoming,
+						))
+					}
+				}
+			}
+
 			if currentNode.handlers != nil && h != nil {
 				panic("handlers are already registered for path '" + ppath + "'")
 			}

--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -301,7 +301,7 @@ func (r *router) insert(path string, h app.HandlersChain, t kind, ppath string, 
 					incoming := pnames[len(pnames)-1]
 					if existing != incoming {
 						panic(fmt.Sprintf(
-							"wildcard name mismatch at the same position: %q vs %q",
+							"parameter name mismatch at the same position: %q vs %q",
 							existing, incoming,
 						))
 					}

--- a/pkg/route/tree_test.go
+++ b/pkg/route/tree_test.go
@@ -735,3 +735,25 @@ func TestTreeParamNotOptimize(t *testing.T) {
 		{"/1", false, "/:paramb", param.Params{param.Param{Key: "paramb", Value: "1"}}},
 	})
 }
+
+func TestWildcardNameMismatchPanic(t *testing.T) {
+	// Param node name mismatch at same position
+	tree := &router{method: "GET", root: &node{}}
+	tree.addRoute("/users/:id", fakeHandler("handler1"))
+	recv := catchPanic(func() {
+		tree.addRoute("/users/:name", fakeHandler("handler2"))
+	})
+	if recv == nil {
+		t.Error("expected panic for param name mismatch, but got none")
+	}
+
+	// Catch-all node name mismatch at same position
+	tree2 := &router{method: "GET", root: &node{}}
+	tree2.addRoute("/files/*path", fakeHandler("handler3"))
+	recv2 := catchPanic(func() {
+		tree2.addRoute("/files/*filepath", fakeHandler("handler4"))
+	})
+	if recv2 == nil {
+		t.Error("expected panic for catch-all name mismatch, but got none")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
fix(route): 在同一位置注册不同参数名/通配符名时优化错误提示

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
When registering two routes with different parameter names or wildcard names at the same path position, the current error message could be more helpful:

```go
// Different param names at same position
router.GET("/users/:id", handler1)
router.GET("/users/:name", handler2) 
// Panic: "handlers are already registered for path '/users/:name'"

// Different catch-all names at same position  
router.GET("/files/*path", handler1)
router.GET("/files/*filepath", handler2)
// Panic: "handlers are already registered for path '/files/*filepath'"