### PR TITLE
fix: Handle nil proxy URI in SetupProxy

### DIFF
--- a/pkg/protocol/http1/proxy/proxy.go
+++ b/pkg/protocol/http1/proxy/proxy.go
@@ -41,6 +41,10 @@ import (
 )
 
 func SetupProxy(conn network.Conn, addr string, proxyURI *protocol.URI, tlsConfig *tls.Config, isTLS bool, dialer network.Dialer) (network.Conn, error) {
+	if proxyURI == nil {
+		return conn, nil
+	}
+
 	var err error
 	if bytes.Equal(proxyURI.Scheme(), bytestr.StrHTTPS) {
 		conn, err = dialer.AddTLS(conn, tlsConfig)
@@ -50,8 +54,6 @@ func SetupProxy(conn network.Conn, addr string, proxyURI *protocol.URI, tlsConfi
 	}
 
 	switch {
-	case proxyURI == nil:
-		// Do nothing. Not using a proxy.
 	case isTLS: // target addr is https
 		connectReq, connectResp := protocol.AcquireRequest(), protocol.AcquireResponse()
 		defer func() {
@@ -113,7 +115,7 @@ func SetupProxy(conn network.Conn, addr string, proxyURI *protocol.URI, tlsConfi
 		}
 	}
 
-	if proxyURI != nil && isTLS {
+	if isTLS {
 		conn, err = dialer.AddTLS(conn, tlsConfig)
 		if err != nil {
 			return nil, err

--- a/pkg/protocol/http1/proxy/proxy_test.go
+++ b/pkg/protocol/http1/proxy/proxy_test.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 CloudWeGo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/cloudwego/hertz/pkg/common/test/mock"
+	"github.com/cloudwego/hertz/pkg/network/dialer"
+)
+
+func TestSetupProxyNilURI(t *testing.T) {
+	conn := mock.NewConn("")
+	got, err := SetupProxy(conn, "example.com:443", nil, nil, true, dialer.DefaultDialer())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != conn {
+		t.Fatalf("unexpected conn: got %p, want %p", got, conn)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?
Changes:

- Return the original connection early when proxyURI == nil to avoid nil pointer dereference inside SetupProxy.
- Remove redundant nil proxy checks after the early return.
- Add TestSetupProxyNilURI to cover the nil proxy URI case and verify the function is safe at its own boundary.