### PR TITLE
fix(route): strip static URL prefix before joining FS root

### DIFF
--- a/pkg/route/routergroup.go
+++ b/pkg/route/routergroup.go
@@ -202,14 +202,25 @@ func (group *RouterGroup) StaticFile(relativePath, filepath string) IRoutes {
 // use :
 //
 //	router.Static("/static", "/var/www")
+//
+// The URL prefix relativePath is stripped before joining with root, so
+// router.Static("/static", "./static") serves ./static/hello.txt at /static/hello.txt.
 func (group *RouterGroup) Static(relativePath, root string) IRoutes {
 	return group.StaticFS(relativePath, &app.FS{Root: root})
 }
 
 // StaticFS works just like `Static()` but a custom `FS` can be used instead.
+//
+// If fs.PathRewrite is nil, the relativePath prefix is stripped from the request
+// path so Root is not joined with the mount prefix twice (see issue #1121).
 func (group *RouterGroup) StaticFS(relativePath string, fs *app.FS) IRoutes {
 	if strings.Contains(relativePath, ":") || strings.Contains(relativePath, "*") {
 		panic("URL parameters can not be used when serving a static folder")
+	}
+	if fs.PathRewrite == nil {
+		if n := countURLPathSegments(relativePath); n > 0 {
+			fs.PathRewrite = app.NewPathSlashesStripper(n)
+		}
 	}
 	handler := fs.NewRequestHandler()
 	urlPattern := path.Join(relativePath, "/*filepath")
@@ -218,6 +229,16 @@ func (group *RouterGroup) StaticFS(relativePath string, fs *app.FS) IRoutes {
 	group.GET(urlPattern, handler)
 	group.HEAD(urlPattern, handler)
 	return group.returnObj()
+}
+
+// countURLPathSegments returns how many slash-separated segments are in p.
+// "/static" -> 1, "/a/b" -> 2, "/" or "" -> 0.
+func countURLPathSegments(p string) int {
+	p = strings.Trim(p, "/")
+	if p == "" {
+		return 0
+	}
+	return strings.Count(p, "/") + 1
 }
 
 func (group *RouterGroup) combineHandlers(handlers app.HandlersChain) app.HandlersChain {

--- a/pkg/route/routergroup_test.go
+++ b/pkg/route/routergroup_test.go
@@ -144,6 +144,33 @@ func TestRouterGroupStatic(t *testing.T) {
 	assert.DeepEqual(t, string(content), w.Body.String())
 }
 
+// TestRouterGroupStaticPrefix ensures URL mount prefix is not joined into Root twice (#1121).
+func TestRouterGroupStaticPrefix(t *testing.T) {
+	dir, err := ioutil.TempDir("", "hertz-static-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	content := []byte("hello-static")
+	if err := ioutil.WriteFile(dir+"/hello.txt", content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	router := NewEngine(config.NewOptions(nil))
+	router.Static("/static", dir)
+	w := performRequest(router, "GET", "/static/hello.txt")
+	assert.DeepEqual(t, http.StatusOK, w.Code)
+	assert.DeepEqual(t, string(content), w.Body.String())
+
+	// trailing slash on mount path
+	router2 := NewEngine(config.NewOptions(nil))
+	router2.Static("/static/", dir)
+	w2 := performRequest(router2, "GET", "/static/hello.txt")
+	assert.DeepEqual(t, http.StatusOK, w2.Code)
+	assert.DeepEqual(t, string(content), w2.Body.String())
+}
+
 func TestRouterGroupStaticFile(t *testing.T) {
 	router := NewEngine(config.NewOptions(nil))
 	router.StaticFile("file", "./engine.go")


### PR DESCRIPTION
Fixes #1121

`Static("/static", "./static")` served `/static/hello.txt` as `./static` + `/static/hello.txt` → `./static/static/hello.txt`.

When `FS.PathRewrite` is nil, strip the mount prefix with `NewPathSlashesStripper` so Root is only joined with the path under the mount.

Test: `TestRouterGroupStaticPrefix` (with and without trailing slash on the mount path).

```
go test ./pkg/route/ -run TestRouterGroupStatic
```