### PR TITLE
fix(http1): avoid mutating headers on failed raw header read

### DIFF
--- a/pkg/protocol/http1/req/header.go
+++ b/pkg/protocol/http1/req/header.go
@@ -82,8 +82,9 @@ func ReadHeaderWithLimit(h *protocol.RequestHeader, r network.Reader, maxHeaderB
 			return err
 		}
 
-		// No more data available on the wire, try block peek
-		if n == r.Len() {
+		// No more data available on the wire, try block peek.
+		// Keep n >= 1: r.Len()==0 would otherwise force a degenerate Peek(0).
+		if n == r.Len() || r.Len() == 0 {
 			n++
 			continue
 		}
@@ -128,10 +129,12 @@ func parse(h *protocol.RequestHeader, buf []byte) (int, error) {
 		return 0, err
 	}
 	rawHeaders, _, err := ext.ReadRawHeaders(h.RawHeaders()[:0], buf[m:])
-	h.SetRawHeaders(rawHeaders)
 	if err != nil {
 		return 0, err
 	}
+	// Only commit raw headers after a successful read so failed parses
+	// do not leave a partially updated header state.
+	h.SetRawHeaders(rawHeaders)
 	n, err := parseHeaders(h, buf[m:])
 	if err != nil {
 		return 0, err
@@ -170,6 +173,9 @@ var errMultipleTE = errors.New("multiple Transfer-Encoding headers are not allow
 
 // request-line = method SP request-target SP HTTP-version CRLF
 func parseFirstLine(h *protocol.RequestHeader, buf []byte) (int, error) {
+	if len(buf) == 0 {
+		return 0, errs.ErrNeedMore
+	}
 	b, leftb, err := utils.NextLine(buf)
 	if err != nil {
 		// errs.ErrNeedMore?


### PR DESCRIPTION
Refs #1497

Small robustness fixes in request header parsing:

1. Only call `SetRawHeaders` after `ReadRawHeaders` succeeds (failed reads no longer leave partial state).
2. When the reader has no buffered data, grow the peek size instead of `Peek(0)`.
3. Early `ErrNeedMore` for empty first-line buffers.

```
go test ./pkg/protocol/http1/req/
```