### PR TITLE
fix(pkg/route): resolve panic in BenchmarkRoute* by resetting ctx.index

### DIFF
--- a/pkg/route/routes_timing_test.go
+++ b/pkg/route/routes_timing_test.go
@@ -627,7 +627,7 @@ func BenchmarkRouteStatic(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.SetIndex(-1)
 	}
 }
 
@@ -640,7 +640,7 @@ func BenchmarkRouteParam(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.SetIndex(-1)
 	}
 }
 
@@ -653,6 +653,6 @@ func BenchmarkRouteAny(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.SetIndex(-1)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
fix

#### Check the PR title.
- [x] This PR title match the format: <type>(optional scope): <description>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

#### (Optional) Translate the PR title into Chinese.
fix(pkg/route): 修复 BenchmarkRoute* 中因 ctx.index 未重置导致的 panic

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
`BenchmarkRouteStatic`、`BenchmarkRouteParam`、`BenchmarkRouteAny` reuse the same `RequestContext` across iterations without resetting `ctx.index`. Since `index` is an `int8`, after 127 successful iterations it overflows to -128, causing `Next()` to access `ctx.handlers[-128]` and panic:
panic: runtime error: index out of range [-128]

text

The source file already has a commented-out line `// ctx.index = -1` — it was commented because `index` is an unexported field from the `app` package and cannot be set directly from `route`. The public method `SetIndex(-1)` was overlooked.

This PR adds `ctx.SetIndex(-1)` at the end of each loop iteration in all three affected benchmarks.

Verified:
```bash
go test ./pkg/route -run='^$' -bench='BenchmarkRouteStatic' -benchmem -count=3
Before: panic
After: PASS, ~28 ns/op

zh(optional):
BenchmarkRouteStatic、BenchmarkRouteParam、BenchmarkRouteAny 在多个迭代间复用同一个 RequestContext，但没有重置 ctx.index。由于 index 为 int8 类型，在 127 次成功迭代后溢出到 -128，导致 Next() 访问 ctx.handlers[-128] 引发 panic。

源文件中已有被注释的 // ctx.index = -1——因 index 是 app 包的非导出字段，无法在 route 包中直接赋值。公开方法 SetIndex(-1) 被遗漏。

此 PR 在三个受影响的 benchmark 循环尾部添加 ctx.SetIndex(-1)。

(Optional) Which issue(s) this PR fixes:
Fixes panic in BenchmarkRouteStatic, BenchmarkRouteParam, BenchmarkRouteAny.