### PR TITLE
Perf/servehttp eliminate path alloc

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -755,7 +755,7 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 		defer engine.recv(ctx)
 	}
 
-	rPath := string(ctx.Request.URI().Path())
+	rPath := bytesconv.B2s(ctx.Request.URI().Path())
 
 	// align with https://datatracker.ietf.org/doc/html/rfc2616#section-5.2
 	if len(ctx.Request.Host()) == 0 && ctx.Request.Header.IsHTTP11() && bytesconv.B2s(ctx.Request.Method()) != consts.MethodConnect {
@@ -767,7 +767,7 @@ func (engine *Engine) ServeHTTP(c context.Context, ctx *app.RequestContext) {
 	httpMethod := bytesconv.B2s(ctx.Request.Header.Method())
 	unescape := false
 	if engine.options.UseRawPath {
-		rPath = string(ctx.Request.URI().PathOriginal())
+		rPath = bytesconv.B2s(ctx.Request.URI().PathOriginal())
 		unescape = engine.options.UnescapePathValues
 	}
 

--- a/pkg/route/routes_timing_test.go
+++ b/pkg/route/routes_timing_test.go
@@ -627,7 +627,7 @@ func BenchmarkRouteStatic(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.SetIndex(-1)
 	}
 }
 
@@ -640,7 +640,7 @@ func BenchmarkRouteParam(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.SetIndex(-1)
 	}
 }
 
@@ -653,6 +653,6 @@ func BenchmarkRouteAny(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r.ServeHTTP(context.Background(), ctx)
-		// ctx.index = -1
+		ctx.SetIndex(-1)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

perf

---

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)

---

#### (Optional) Translate the PR title into Chinese.

perf(pkg/route): 消除 ServeHTTP 中每次请求的路径字符串分配

---

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
## Background

`pkg/route/engine.go:ServeHTTP` performs a `[]byte → string` conversion on every request for route matching:

```go
rPath := string(ctx.Request.URI().Path())
```

`BenchmarkRouteStatic` shows 1 alloc (8B) per request end-to-end.

## Evidence Chain

### 1. Baseline benchmark

```
BenchmarkRouteStatic-32   26000000   45.5 ns/op   8 B/op   1 allocs/op
BenchmarkRouteParam -32   22000000   57.0 ns/op   8 B/op   1 allocs/op
BenchmarkRouteAny   -32   14000000   87.6 ns/op  24 B/op   2 allocs/op
```

### 2. Memory profile points to a single line

```bash
go test ./pkg/route -run='^$' -bench='BenchmarkRouteStatic' \
  -memprofile=mem.out -outputdir .
go tool pprof -alloc_objects -list "ServeHTTP" mem.out
```

Output:

```
ROUTINE ============ github.com/cloudwego/hertz/pkg/route.(*Engine).ServeHTTP
  19890479   19890479 (flat, cum) 99.49% of Total
         .          .    752: func (engine *Engine) ServeHTTP(...)
         .          .    753:   ctx.SetBinder(engine.binder)
         .          .    754:   if engine.PanicHandler != nil {
         .          .    755:     defer engine.recv(ctx)
         .          .    756:   }
  19890479   19890479    758:   rPath := string(ctx.Request.URI().Path())
```

`engine.go:758` alone accounts for 19.89M allocations, 99.49% of total.

### 3. Micro-benchmark quantifying the pure overhead

```go
var result string

func BenchmarkPathStringConversion(b *testing.B) {
    path := []byte("/hi/foo")
    b.ReportAllocs()
    b.ResetTimer()
    for i := 0; i < b.N; i++ {
        result = string(path)
    }
}

func BenchmarkPathB2SConversion(b *testing.B) {
    path := []byte("/hi/foo")
    b.ReportAllocs()
    b.ResetTimer()
    for i := 0; i < b.N; i++ {
        result = bytesconv.B2s(path)
    }
}
```

Results:

```
BenchmarkPathStringConversion-32   100000000   11.2 ns/op   8 B/op   1 allocs/op
BenchmarkPathB2SConversion   -32  1000000000   0.36 ns/op  0 B/op   0 allocs/op
```

Pure conversion performance differs by ~30x, and B2s has zero allocations.

### 4. Consistency evidence

Within the same file, `redirectTrailingSlash` (engine.go:866) and `redirectFixedPath` (engine.go:893) already use `bytesconv.B2s(ctx.Request.URI().Path())`. The framework already follows this convention — `ServeHTTP` was simply missed.

## Fix

`pkg/route/engine.go`:

```diff
- rPath := string(ctx.Request.URI().Path())
+ rPath := bytesconv.B2s(ctx.Request.URI().Path())
```

`UseRawPath` branch synchronized:

```diff
- rPath = string(ctx.Request.URI().PathOriginal())
+ rPath = bytesconv.B2s(ctx.Request.URI().PathOriginal())
```

## Safety Analysis

- `bytesconv.B2s` returns the underlying data of `[]byte` directly as a `string` via unsafe pointer conversion — zero-copy.
- In `ServeHTTP`, `rPath` is only used within this function's scope for route matching. It is not passed to asynchronous code or held long-term.
- The buffer returned by `ctx.Request.URI().Path()` is not reused/released until the current request processing completes. This shares the same lifecycle as the existing zero-copy usage in `redirectTrailingSlash` — safety-equivalent.

## Regression Tests

```bash
go test ./pkg/route/... -race
```

All PASS. No functional breakage. No data races.

## Benchmark Comparison

Same machine: AMD Ryzen 9 8945HX, Windows/amd64, Go 1.x, `-count=3`:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| BenchmarkRouteStatic | 45.5 ns/op, 8 B, 1 alloc | 20.2 ns/op, 0 B, 0 alloc | -56% / -1 alloc |
| BenchmarkRouteParam | 57.0 ns/op, 8 B, 1 alloc | 25.5 ns/op, 0 B, 0 alloc | -55% / -1 alloc |
| BenchmarkRouteAny | 87.6 ns/op, 24 B, 2 alloc | 35.9 ns/op, 8 B, 1 alloc | -59% / -1 alloc |

`Tree_Find*` benchmarks show no change (expected — serving as regression reference).

## Why the benefit exceeds the micro-benchmark expectation

- The micro-benchmark only measures the conversion itself (~11 ns / 1 alloc lower bound).
- End-to-end additionally eliminates `mallocgc` paths, GC write barriers, `bgsweep`, and other collateral overhead — the original CPU profile shows `runtime.gcBgMarkWorker`, `runtime.systemstack`, and `runtime.bgsweep` collectively account for ~36%.
- After eliminating 19.89M allocations, these GC paths have almost nothing to do.

## Remaining Optimization Potential

`BenchmarkRouteAny` still has 1 remaining 8B allocation, coming from slice copying of remaining path for `*param` wildcard matching in `tree.go`. This belongs to internal route matching logic with a broader impact surface and is out of scope for this PR.

zh(optional):
## 背景

`pkg/route/engine.go:ServeHTTP` 每次请求会做一次 `[]byte → string` 转换用于路由匹配。`BenchmarkRouteStatic` 显示 end-to-end 每请求存在 1 次 8B 分配。

## 定位过程（证据链）

### 1. 基线 benchmark
### 2. 内存 profile 指向单行

`engine.go:758` 独占 1989 万次分配，占 99.49%。

### 3. Micro-benchmark 量化纯开销

纯转换性能相差 ~30x，且 B2s 零分配。

### 4. 一致性证据

同文件内 `redirectTrailingSlash`（engine.go:866）和 `redirectFixedPath`（engine.go:893）已经使用 `bytesconv.B2s(ctx.Request.URI().Path())`，可见框架已有这一约定，`ServeHTTP` 是漏改。

## 修复

`pkg/route/engine.go`：

```diff
- rPath := string(ctx.Request.URI().Path())
+ rPath := bytesconv.B2s(ctx.Request.URI().Path())
```

`UseRawPath` 分支同步处理：

```diff
- rPath = string(ctx.Request.URI().PathOriginal())
+ rPath = bytesconv.B2s(ctx.Request.URI().PathOriginal())
```

## 安全性分析

- `bytesconv.B2s` 通过 unsafe 指针把 `[]byte` 的底层数据直接当作 `string` 返回，零拷贝。
- `ServeHTTP` 中 `rPath` 仅在本函数作用域内用于路由匹配，不会传入异步代码或被长期持有。
- `ctx.Request.URI().Path()` 返回的 buffer 在本次请求处理完成前不会被复用/释放，与 `redirectTrailingSlash` 已有的零拷贝用法处于相同生命周期，安全等价。

## 回归测试

全部 PASS，无功能破坏，无数据竞争。

## Benchmark 对比

同机 AMD Ryzen 9 8945HX，Windows/amd64，Go 1.x，`-count=3`：

| Benchmark | 修复前 | 修复后 | Δ |
|---|---|---|---|
| BenchmarkRouteStatic | 45.5 ns/op, 8 B, 1 alloc | 20.2 ns/op, 0 B, 0 alloc | -56% / -1 alloc |
| BenchmarkRouteParam | 57.0 ns/op, 8 B, 1 alloc | 25.5 ns/op, 0 B, 0 alloc | -55% / -1 alloc |
| BenchmarkRouteAny | 87.6 ns/op, 24 B, 2 alloc | 35.9 ns/op, 8 B, 1 alloc | -59% / -1 alloc |

`Tree_Find*` benchmark 无变化（不应受影响，作为回归参照）。

## 收益超出 micro-benchmark 预期的原因

- Micro-benchmark 只测了转换本身（~11 ns / 1 alloc 下限）。
- end-to-end 还顺带消除了 `mallocgc` 路径、GC 写屏障、`bgsweep` 等连带开销——原 CPU profile 中 `runtime.gcBgMarkWorker`、`runtime.systemstack`、`runtime.bgsweep` 合计占 ~36%。
- 消除 1989 万次分配后，这些 GC 路径几乎无事可做。


---

#### (Optional) Which issue(s) this PR fixes:

---

#### (Optional) The PR that updates user documentation:

---