### PR TITLE
fix: reject empty HTTP trailer tokens

### DIFF
--- a/pkg/protocol/trailer.go
+++ b/pkg/protocol/trailer.go
@@ -163,6 +163,9 @@ func (t *Trailer) SetTrailers(trailers []byte) (err error) {
 		for len(trailerKey) > 0 && trailerKey[len(trailerKey)-1] == ' ' {
 			trailerKey = trailerKey[:len(trailerKey)-1]
 		}
+		if len(trailerKey) == 0 {
+			return errs.NewPublicf("empty trailer key")
+		}
 
 		utils.NormalizeHeaderKey(trailerKey, t.disableNormalizing)
 		err = t.addArgBytes(trailerKey, nil, argsNoValue)
@@ -186,6 +189,9 @@ func (t *Trailer) AppendBytes(dst []byte) []byte {
 }
 
 func IsBadTrailer(key []byte) bool {
+	if len(key) == 0 {
+		return true
+	}
 	switch key[0] | 0x20 {
 	case 'a':
 		return utils.CaseInsensitiveCompare(key, bytestr.StrAuthorization)

--- a/pkg/protocol/trailer_test.go
+++ b/pkg/protocol/trailer_test.go
@@ -72,6 +72,14 @@ func TestHeaderTrailerSet(t *testing.T) {
 	assert.True(t, strings.Contains(string(h.Trailer().Header()), "Aaa:"))
 }
 
+func TestTrailerSetTrailersRejectsEmptyKey(t *testing.T) {
+	var tr Trailer
+	assert.NotNil(t, tr.SetTrailers([]byte(",")))
+	assert.True(t, tr.Empty())
+	assert.NotNil(t, tr.SetTrailers([]byte("foo, ")))
+	assert.False(t, tr.Empty())
+}
+
 func TestTrailerAddError(t *testing.T) {
 	var tr Trailer
 	assert.NotNil(t, tr.Add(consts.HeaderContentType, ""))
@@ -140,6 +148,8 @@ func TestTrailerVisitAll(t *testing.T) {
 }
 
 func TestIsBadTrailer(t *testing.T) {
+	assert.True(t, IsBadTrailer(nil))
+	assert.True(t, IsBadTrailer([]byte{}))
 	assert.True(t, IsBadTrailer(bytestr.StrAuthorization))
 	assert.True(t, IsBadTrailer(bytestr.StrContentEncoding))
 	assert.True(t, IsBadTrailer(bytestr.StrContentLength))


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->