### PR TITLE
fix: replace debug fmt.Println with hlog in printNode

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -734,9 +734,9 @@ func (engine *Engine) PrintRoute(method string) {
 
 // debug use
 func printNode(node *node, level int) {
-	fmt.Println("node.prefix: " + node.prefix)
-	fmt.Println("node.ppath: " + node.ppath)
-	fmt.Printf("level: %#v\n\n", level)
+	hlog.SystemLogger().Debugf("node.prefix: %s", node.prefix)
+	hlog.SystemLogger().Debugf("node.ppath: %s", node.ppath)
+	hlog.SystemLogger().Debugf("level: %d", level)
 	for i := 0; i < len(node.children); i++ {
 		printNode(node.children[i], level+1)
 	}


### PR DESCRIPTION
## Problem

\printNode()\ function in \engine.go\ uses \mt.Println\ and \mt.Printf\ for debug output, which writes directly to stdout instead of using hertz's logging framework (\hlog\).

## Impact

- Debug output bypasses the logging system configuration
- Cannot control log level or output destination for these messages
- Inconsistent with the rest of the codebase which uses \hlog.SystemLogger()\

## Fix

Replace \mt.Println\/\mt.Printf\ calls with \hlog.SystemLogger().Debugf()\ to integrate with hertz's logging framework.

Closes #1525

Local environment limitations, relying on CI/CD automated testing.