### PR TITLE
style: remove redundant comment in binding config

### DIFF
--- a/pkg/app/server/binding/config.go
+++ b/pkg/app/server/binding/config.go
@@ -96,7 +96,6 @@ func NewBindConfig() *BindConfig {
 
 // RegTypeUnmarshal registers customized type unmarshaler.
 func (config *BindConfig) RegTypeUnmarshal(t reflect.Type, fn inDecoder.CustomizeDecodeFunc) error {
-	// check
 	switch t.Kind() {
 	case reflect.String, reflect.Bool,
 		reflect.Float32, reflect.Float64,


### PR DESCRIPTION
#### What type of PR is this?

style

#### Check the PR title.
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. `https://github.com/cloudwego/cloudwego.github.io`

#### (Optional) Translate the PR title into Chinese.

style: 移除 binding config 中冗余的注释

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en: Remove the redundant `// check` comment above the `switch` statement in `BindConfig.RegTypeUnmarshal`. The comment adds no information beyond what the code already conveys.
zh(optional): 删除 `BindConfig.RegTypeUnmarshal` 中 `switch` 语句上方冗余的 `// check` 注释，该注释未提供任何超出代码本身的信息。

#### (Optional) Which issue(s) this PR fixes:

N/A

#### (Optional) The PR that updates user documentation:

N/A