### PR TITLE
docs: add v0.10.6 changelog

### DIFF
--- a/changelog/v0.10.6.md
+++ b/changelog/v0.10.6.md
@@ -1,0 +1,21 @@
+## Features
+- client: Add `WithPooledConnHealthCheck` to discard stale idle pooled connections before reuse; disabled by default (#1523)
+
+## Fixes
+- protocol/client: Remove sensitive headers when redirects change host or downgrade from HTTPS to HTTP (#1524)
+- protocol: Reject empty HTTP trailer tokens that could panic `IsBadTrailer` (#1522)
+
+## Deps
+- Bump github.com/cloudwego/netpoll v0.7.3 -> v0.7.5 (#1523)
+
+## Commits (v0.10.5..v0.10.6)
+- 1caa689 chore: prepare for v0.10.6 release (#1528)
+- b7d8dad feat(client): add optional pooled connection health check (#1523)
+- ec82961 fix: sanitize request headers during unsafe redirects (#1524)
+- 1f85d7a Merge branch 'main' into main
+- e1f9a89 fix: redirect with wrong data
+- b2f1264 fix: reject empty HTTP trailer tokens (#1522)
+- b1033ee fix: reject empty HTTP trailer tokens
+- 8eec17d ci: deprecate self-hosted arm64, MacOS (#1514)
+- 9297a3c docs: add v0.10.5 changelog (#1512)
+- 8c9ca11 docs: add v0.10.5 changelog


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
docs
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->