### PR TITLE
fix(route): replace debug prints with hlog in printNode

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -734,9 +734,9 @@ func (engine *Engine) PrintRoute(method string) {
 
 // debug use
 func printNode(node *node, level int) {
-	fmt.Println("node.prefix: " + node.prefix)
-	fmt.Println("node.ppath: " + node.ppath)
-	fmt.Printf("level: %#v\n\n", level)
+	hlog.SystemLogger().Debugf("node.prefix: %s", node.prefix)
+	hlog.SystemLogger().Debugf("node.ppath: %s", node.ppath)
+	hlog.SystemLogger().Debugf("level: %#v\n\n", level)
 	for i := 0; i < len(node.children); i++ {
 		printNode(node.children[i], level+1)
 	}

--- a/pkg/route/engine_test.go
+++ b/pkg/route/engine_test.go
@@ -41,6 +41,7 @@
 package route
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -49,6 +50,8 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -60,6 +63,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/app/server/registry"
 	"github.com/cloudwego/hertz/pkg/common/config"
 	errs "github.com/cloudwego/hertz/pkg/common/errors"
+	"github.com/cloudwego/hertz/pkg/common/hlog"
 	"github.com/cloudwego/hertz/pkg/common/test/assert"
 	"github.com/cloudwego/hertz/pkg/common/test/mock"
 	"github.com/cloudwego/hertz/pkg/network"
@@ -96,6 +100,37 @@ func TestNew_Engine_WithTransporter(t *testing.T) {
 func TestGetTransporterName(t *testing.T) {
 	name := getTransporterName(&fakeTransporter{})
 	assert.DeepEqual(t, "route", name)
+}
+
+func TestPrintNode(t *testing.T) {
+	var output bytes.Buffer
+	hlog.SetOutput(&output)
+	hlog.SetLevel(hlog.LevelDebug)
+	t.Cleanup(func() {
+		hlog.SetOutput(os.Stderr)
+		hlog.SetLevel(hlog.LevelTrace)
+	})
+
+	root := &node{
+		prefix: "root",
+		ppath:  "/root",
+		children: children{
+			&node{
+				prefix: "child",
+				ppath:  "/root/child",
+			},
+		},
+	}
+
+	printNode(root, 0)
+
+	logs := output.String()
+	assert.True(t, strings.Contains(logs, "node.prefix: root"))
+	assert.True(t, strings.Contains(logs, "node.ppath: /root"))
+	assert.True(t, strings.Contains(logs, "level: 0"))
+	assert.True(t, strings.Contains(logs, "node.prefix: child"))
+	assert.True(t, strings.Contains(logs, "node.ppath: /root/child"))
+	assert.True(t, strings.Contains(logs, "level: 1"))
 }
 
 func TestEngineUnescape(t *testing.T) {


### PR DESCRIPTION
## What this PR does

- Replace direct `fmt.Println` and `fmt.Printf` calls in `printNode` with `hlog.SystemLogger().Debugf`.
- Keep the existing route tree output and recursive behavior unchanged.
- Add a regression test covering root and child node logging.

## Motivation

`printNode` currently writes debug information directly to stdout, bypassing Hertz's logging configuration, log level, and output destination.

This change routes the debug output through Hertz's logging framework.

Fixes #1525

## Tests

- `go test ./pkg/route`
- `go test ./...`
- `go test ./pkg/route -run '^TestPrintNode$' -count=20`
- `git diff --check`