### PR TITLE
fix: replace debug fmt.Println with hlog in printNode

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -734,9 +734,9 @@ func (engine *Engine) PrintRoute(method string) {
 
 // debug use
 func printNode(node *node, level int) {
-	fmt.Println("node.prefix: " + node.prefix)
-	fmt.Println("node.ppath: " + node.ppath)
-	fmt.Printf("level: %#v\n\n", level)
+	hlog.SystemLogger().Debugf("node.prefix: %s", node.prefix)
+	hlog.SystemLogger().Debugf("node.ppath: %s", node.ppath)
+	hlog.SystemLogger().Debugf("level: %d\n", level)
 	for i := 0; i < len(node.children); i++ {
 		printNode(node.children[i], level+1)
 	}


### PR DESCRIPTION
## Description

Replace debug `fmt.Println`/`fmt.Printf` calls in `printNode()` with `hlog.SystemLogger().Debugf()` to use the proper logging framework.

### Problem

`printNode()` in `engine.go` uses `fmt.Println` and `fmt.Printf` for debug output, which writes directly to stdout instead of using Hertz's logging framework (`hlog`).

This causes:
- Debug output bypasses the logging system configuration
- Cannot control log level or output destination for these messages
- Inconsistent with the rest of the codebase which uses `hlog.SystemLogger()`

### Fix

Replace `fmt.Println`/`fmt.Printf` calls with `hlog.SystemLogger().Debugf()`.

### Changes

- `pkg/route/engine.go`: Replace 3 `fmt.Print*` calls in `printNode()` with `hlog.SystemLogger().Debugf()`

### Testing

- `go build ./pkg/route/...` pass
- `go test ./pkg/route/...` pass (1.7s)

### Related

- Fixes #1525
