### PR TITLE
refactor: remove unused findChild method from node

### DIFF
--- a/pkg/route/tree.go
+++ b/pkg/route/tree.go
@@ -386,14 +386,14 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 			if search == "/" && cn.handlers != nil {
 				res.tsr = true
 			}
-			if child := cn.findChild(search[0]); child != nil {
+			if child := cn.findChildWithLabel(search[0]); child != nil {
 				cn = child
 				continue
 			}
 		}
 
 		if search == nilString {
-			if cd := cn.findChild('/'); cd != nil && (cd.handlers != nil || cd.anyChild != nil) {
+			if cd := cn.findChildWithLabel('/'); cd != nil && (cd.handlers != nil || cd.anyChild != nil) {
 				res.tsr = true
 			}
 		}
@@ -418,7 +418,7 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 			search = search[i:]
 			searchIndex = searchIndex + i
 			if search == nilString {
-				if cd := cn.findChild('/'); cd != nil && (cd.handlers != nil || cd.anyChild != nil) {
+				if cd := cn.findChildWithLabel('/'); cd != nil && (cd.handlers != nil || cd.anyChild != nil) {
 					res.tsr = true
 				}
 			}
@@ -469,15 +469,6 @@ func (r *router) find(path string, paramsPointer *param.Params, unescape bool) (
 	}
 
 	return
-}
-
-func (n *node) findChild(l byte) *node {
-	for _, c := range n.children {
-		if c.label == l {
-			return c
-		}
-	}
-	return nil
 }
 
 func (n *node) findChildWithLabel(l byte) *node {


### PR DESCRIPTION
## What

Remove the `findChild` method from `node` and replace its 3 call sites with `findChildWithLabel`.

## Why

`findChild` is a strict subset of `findChildWithLabel` — it only searches `children`, while `findChildWithLabel` also checks `paramChild` and `anyChild`. All 3 call sites search for '/' or other non-param/any characters, so the behavior is identical. Keeping both methods adds confusion without benefit.

## Changes

- `tree.go`: delete `findChild` method (8 lines)
- `tree.go`: replace 3 `findChild` calls with `findChildWithLabel`

## Testing

```
go test ./pkg/route/...
```

All existing tests pass. This is a pure refactor with no behavior change.

Closes #1504