### PR TITLE
fix(resp): correct ConnectionUpgrade to check for Upgrade instead of keep-alive

### DIFF
--- a/pkg/protocol/http1/resp/header.go
+++ b/pkg/protocol/http1/resp/header.go
@@ -100,7 +100,7 @@ func WriteHeader(h *protocol.ResponseHeader, w network.Writer) error {
 
 // ConnectionUpgrade returns true if 'Connection: Upgrade' header is set.
 func ConnectionUpgrade(h *protocol.ResponseHeader) bool {
-	return ext.HasHeaderValue(h.Peek(consts.HeaderConnection), bytestr.StrKeepAlive)
+	return ext.HasHeaderValue(h.Peek(consts.HeaderConnection), bytestr.StrUpgrade)
 }
 
 func tryRead(h *protocol.ResponseHeader, r network.Reader, n int) error {


### PR DESCRIPTION
## What

Fix `ConnectionUpgrade()` in `resp/header.go` which was incorrectly checking for `keep-alive` instead of `Upgrade` in the Connection header.

## Why

The function name and comment clearly state it should check for `Connection: Upgrade`, but the implementation was using `bytestr.StrKeepAlive` instead of `bytestr.StrUpgrade`.

This bug affects WebSocket support: when a response has `Connection: Upgrade` (as in WebSocket handshakes), `ConnectionUpgrade()` returns `false`, causing the code at line 204 to incorrectly set `Transfer-Encoding: identity` and close the connection.

Conversely, regular keep-alive responses would incorrectly trigger the upgrade path.

## Changes

- `resp/header.go`: change `bytestr.StrKeepAlive` to `bytestr.StrUpgrade` in `ConnectionUpgrade()`

## Testing

```
go test ./pkg/protocol/http1/resp/...
```

All existing tests pass. This is a one-line bug fix.