### PR TITLE
fix(bytesconv): detect integer overflow before multiplication in ParseUintBuf

### DIFF
--- a/internal/bytesconv/bytesconv.go
+++ b/internal/bytesconv/bytesconv.go
@@ -42,6 +42,7 @@
 package bytesconv
 
 import (
+	"math"
 	"net/http"
 	"time"
 	"unsafe"
@@ -162,12 +163,13 @@ func ParseUintBuf(b []byte) (int, int, error) {
 			}
 			return v, i, nil
 		}
-		vNew := 10*v + int(k)
-		// Test for overflow.
-		if vNew < v {
+		// Test for overflow before multiplying, because 10*v may wrap around
+		// to a value that is still greater than v, which would make a
+		// post-multiplication check unreliable.
+		if v > (math.MaxInt-int(k))/10 {
 			return -1, i, errTooLongInt
 		}
-		v = vNew
+		v = 10*v + int(k)
 	}
 	return v, n, nil
 }

--- a/internal/bytesconv/bytesconv_64_test.go
+++ b/internal/bytesconv/bytesconv_64_test.go
@@ -104,6 +104,12 @@ func TestParseUintError(t *testing.T) {
 		{"-9223372036854775808"},
 		{"9223372036854775808"},
 		{"18446744073709551615"},
+		// Values whose intermediate 10*v wraps past 2^64 and lands back on a
+		// positive number, which a post-multiplication overflow check misses.
+		{"21000000000000000000"},
+		{"25000000000000000000"},
+		{"46000000000000000000"},
+		{"83000000000000000000"},
 	} {
 		n, err := ParseUint(S2b(v.s))
 		if err == nil {


### PR DESCRIPTION
## What this PR does

`ParseUintBuf` checks for overflow *after* the multiplication:

```go
vNew := 10*v + int(k)
// Test for overflow.
if vNew < v {
    return -1, i, errTooLongInt
}
```

When `10*v` itself overflows, the wrapped result can still be greater than `v`,
so the check silently passes and the function returns a wrapped value instead of
`errTooLongInt`.

This PR moves the check before the multiplication.

## Reproduce

`ParseUint` accepts out-of-range input and returns a wrapped value:

| input | before | after |
|---|---|---|
| `21000000000000000000` | `2553255926290448384`, `err == nil` | `errTooLongInt` |
| `25000000000000000000` | `6553255926290448384`, `err == nil` | `errTooLongInt` |

Scanning all 90 twenty-digit inputs of the form `dd000000000000000000`, 18 of
them are accepted although they exceed `math.MaxInt`.

Note the inconsistency: `18446744073709551616` is correctly rejected today,
while the numerically smaller `21000000000000000000` is accepted.

## Impact

`ParseUintBuf` backs `protocol.ParseContentLength`, so the value comes from an
untrusted request header. Parsing a real request through `ReadHeader`:

```
Content-Length: 25000000000000000000  =>  ContentLength() = 6553255926290448384, err = nil
Content-Length: 18446744073709551616  =>  rejected ("too long int")
```

`ParseUint` is also used for the `Range` header (`pkg/app/fs.go`) and the cookie
`max-age` attribute (`pkg/protocol/cookie.go`).

## Notes

- Uses `math.MaxInt` so the bound follows the platform word size; verified
  `GOARCH=386` and `GOARCH=arm` still build.
- Reuses the existing `errTooLongInt`; no new error value and no signature change.
- The boundary value `9223372036854775807` is still accepted, covered by the
  existing `TestParseUint`.

## Verification

- Added the missed inputs to the existing `TestParseUintError`; they fail before
  this change and pass after it.
- `go test ./...` passes.
- `gofmt -l` and `go vet` are clean.

I could not open an issue first as suggested by `CONTRIBUTING.md`, because issue
creation is restricted in this repository, so the full reproduction is included
above. Happy to move this to an issue or another channel if you prefer.
