### PR TITLE
test(route): avoid leaking temp files on Windows

### DIFF
--- a/pkg/route/routes_test.go
+++ b/pkg/route/routes_test.go
@@ -43,10 +43,8 @@ package route
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -396,30 +394,20 @@ func TestRouteParamsByNameWithExtraSlash(t *testing.T) {
 
 // TestHandleStaticFile - ensure the static file handles properly
 func TestRouteStaticFile(t *testing.T) {
-	// SETUP file
-	testRoot, _ := os.Getwd()
-	f, err := ioutil.TempFile(testRoot, "")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.Remove(f.Name())
-	_, err = f.WriteString("Hertz Web Framework")
-	assert.Nil(t, err)
-	f.Close()
-
-	dir, filename := filepath.Split(f.Name())
+	filePath := "../common/testdata/test.txt"
+	dir, filename := filepath.Split(filePath)
 
 	// SETUP engine
 	router := NewEngine(config.NewOptions(nil))
 	router.StaticFS("/using_static", &app.FS{Root: dir, AcceptByteRange: true, PathRewrite: app.NewPathSlashesStripper(1)})
-	router.StaticFile("/result", f.Name())
+	router.StaticFile("/result", filePath)
 
 	w := performRequest(router, consts.MethodGet, "/using_static/"+filename)
 	w2 := performRequest(router, consts.MethodGet, "/result")
 
 	assert.DeepEqual(t, w, w2)
 	assert.DeepEqual(t, consts.StatusOK, w.Code)
-	assert.DeepEqual(t, "Hertz Web Framework", w.Body.String())
+	assert.DeepEqual(t, "hello world!", w.Body.String())
 	assert.DeepEqual(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
 
 	w3 := performRequest(router, consts.MethodHead, "/using_static/"+filename)


### PR DESCRIPTION
#### What type of PR is this?

test

#### Check the PR title.

- [x] This PR title matches the format: `<type>(optional scope): <description>`
- [x] The description is user-oriented and clear enough for others to understand.
- [x] User documentation is not required because this only changes a test fixture.

#### (Optional) Translate the PR title into Chinese.

测试（route）：避免在 Windows 上泄漏临时文件

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:

`TestRouteStaticFile` created a temporary fixture inside `pkg/route`. The static-file handler keeps the file open in its cache, so the deferred removal fails on Windows and every successful run leaves a random untracked file behind.

Reuse the existing tracked `pkg/common/testdata/test.txt` fixture instead. This preserves the GET/HEAD and `StaticFS`/`StaticFile` equivalence coverage without requiring cleanup or changing production behavior.

Verification:

- `go test ./pkg/route -run '^TestRouteStaticFile$' -count=2 -v`
- `go vet ./pkg/route`
- `go test -count=1 ./...`
- `go build ./...`
- confirmed no numeric files remain under `pkg/route` after the focused and full test runs

zh(optional):

复用现有的 tracked 文本 fixture，避免 `TestRouteStaticFile` 在 Windows 上因缓存文件句柄而无法删除临时文件。

#### (Optional) Which issue(s) this PR fixes:

Fixes #1540

#### (Optional) The PR that updates user documentation:

Not applicable; this is a test-only cleanup fix.