### PR TITLE
fix: resolve redirect locations with absolute URLs in query

### DIFF
--- a/pkg/protocol/client/client_test.go
+++ b/pkg/protocol/client/client_test.go
@@ -229,3 +229,8 @@ func TestDoRequestFollowRedirectsTooManyRedirects(t *testing.T) {
 	assert.ErrorIs(t, err, errTooManyRedirects)
 	assert.Equal(t, consts.StatusFound, statusCode)
 }
+
+func TestGetRedirectURLWithAbsoluteURLInQuery(t *testing.T) {
+	redirectURL := getRedirectURL("https://example.com/", []byte("/login/redirect_to_sso?redirect=https://example.com/"))
+	assert.Equal(t, "https://example.com/login/redirect_to_sso?redirect=https://example.com/", redirectURL)
+}

--- a/pkg/protocol/uri.go
+++ b/pkg/protocol/uri.go
@@ -597,15 +597,14 @@ func (u *URI) updateBytes(newURI, buf []byte) []byte {
 		return buf
 	}
 
-	n := bytes.Index(newURI, bytestr.StrSlashSlash)
-	if n >= 0 {
+	if isAbsoluteURI(newURI) {
 		// absolute uri
 		var b [32]byte
 		schemeOriginal := b[:0]
 		if len(u.scheme) > 0 {
 			schemeOriginal = append([]byte(nil), u.scheme...)
 		}
-		if n == 0 {
+		if bytes.HasPrefix(newURI, bytestr.StrSlashSlash) {
 			newURI = bytes.Join([][]byte{u.scheme, bytestr.StrColon, newURI}, nil)
 		}
 		u.Parse(nil, newURI)
@@ -636,7 +635,7 @@ func (u *URI) updateBytes(newURI, buf []byte) []byte {
 	default:
 		// update the last path part after the slash
 		path := u.Path()
-		n = bytes.LastIndexByte(path, '/')
+		n := bytes.LastIndexByte(path, '/')
 		if n < 0 {
 			panic("BUG: path must contain at least one slash")
 		}
@@ -646,6 +645,14 @@ func (u *URI) updateBytes(newURI, buf []byte) []byte {
 		u.Parse(nil, buf)
 		return buf
 	}
+}
+
+func isAbsoluteURI(uri []byte) bool {
+	if bytes.HasPrefix(uri, bytestr.StrSlashSlash) {
+		return true
+	}
+	_, path := getScheme(uri)
+	return bytes.HasPrefix(path, bytestr.StrSlashSlash)
 }
 
 // AppendBytes appends full uri to dst and returns the extended dst.

--- a/pkg/protocol/uri_test.go
+++ b/pkg/protocol/uri_test.go
@@ -281,6 +281,7 @@ func TestURIUpdate(t *testing.T) {
 
 	// request uri
 	testURIUpdate(t, "ftp://aaa/xxx/yyy?aaa=bb#aa", "/boo/bar?xx", "ftp://aaa/boo/bar?xx")
+	testURIUpdate(t, "https://example.com/", "/login/redirect_to_sso?redirect=https://example.com/", "https://example.com/login/redirect_to_sso?redirect=https://example.com/")
 
 	// relative uri
 	testURIUpdate(t, "http://foo.bar/baz/xxx.html?aaa=22#aaa", "bb.html?xx=12#pp", "http://foo.bar/baz/bb.html?xx=12#pp")


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
corresponding issue: https://github.com/cloudwego/hertz/issues/1539

Fix `protocol.URI.Update` / `UpdateBytes` resolving relative URLs incorrectly when the query string contains an absolute URL.

Previously, `UpdateBytes` treated any `//` in the new URI as an absolute URI marker. For redirect locations like:

```text
/login/redirect_to_sso?redirect=https://example.com/
```
the // inside https:// caused the relative location to be reparsed as an absolute URI, resulting in an empty host and default http scheme.
This PR changes the absolute URI detection to only match:
- network-path references starting with //
- absolute URIs with scheme://


#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.


#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en:
zh(optional):

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (Optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->