### PR TITLE
fix(route): only log HTTP2 fallback on HTTP2 request

### DIFF
--- a/pkg/route/engine.go
+++ b/pkg/route/engine.go
@@ -517,10 +517,12 @@ func (engine *Engine) Serve(c context.Context, conn network.Conn) (err error) {
 	if engine.options.H2C {
 		// protocol sniffer
 		buf, _ := conn.Peek(len(bytestr.StrClientPreface))
-		if bytes.Equal(buf, bytestr.StrClientPreface) && engine.protocolServers[suite.HTTP2] != nil {
-			return engine.protocolServers[suite.HTTP2].Serve(c, conn)
+		if bytes.Equal(buf, bytestr.StrClientPreface) {
+			if engine.protocolServers[suite.HTTP2] != nil {
+				return engine.protocolServers[suite.HTTP2].Serve(c, conn)
+			}
+			hlog.SystemLogger().Warn("HTTP2 server is not loaded, request is going to fallback to HTTP1 server")
 		}
-		hlog.SystemLogger().Warn("HTTP2 server is not loaded, request is going to fallback to HTTP1 server")
 	}
 
 	// ALPN path


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
fix(route): 仅在客户端发起 HTTP2 请求时打印 HTTP2 降级日志

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
<!--
Provide more detailed info for review(e.g., it's recommended to provide perf data if this is a perf type PR).
-->
en: After enabling H2C, this warning log is incorrectly triggered even for non-HTTP2 requests
zh: 配置 H2C 后，发起非 HTTP2 请求会误触发此日志